### PR TITLE
fix(web): preserve request body semantics in browser transport

### DIFF
--- a/lib/src/_internal/transport.web.dart
+++ b/lib/src/_internal/transport.web.dart
@@ -1,9 +1,11 @@
 import 'dart:js_interop';
+import 'dart:typed_data';
 
 import 'package:ht/ht.dart';
 
 import '../errors.dart';
 import '../options.dart';
+import 'web_request_body_mode.dart';
 import 'web_stream_utils.dart';
 
 extension type IteratorReturnResult._(JSObject _) implements JSObject {
@@ -41,14 +43,14 @@ extension type RequestInit._(JSObject _) implements JSObject {
   external factory RequestInit({
     String? method,
     WebHeaders? headers,
-    ReadableStream? body,
+    JSAny? body,
     bool? keepalive,
     String? redirect,
     String? duplex,
     WebAbortSignal? signal,
   });
 
-  external ReadableStream? body;
+  external JSAny? body;
   external String? duplex;
   external WebAbortSignal? signal;
 }
@@ -96,8 +98,12 @@ Future<Response> fetchTransport(Request request, RequestOptions options) async {
 
   final requestBody = request.body;
   if (requestBody != null) {
-    init.body = toWebReadableStream(requestBody);
-    init.duplex = 'half';
+    if (_requestBodyMode(options) == WebRequestBodyMode.streaming) {
+      init.body = toWebReadableStream(requestBody);
+      init.duplex = 'half';
+    } else {
+      init.body = (await _materializeRequestBody(requestBody)).toJS;
+    }
   }
 
   try {
@@ -169,6 +175,22 @@ Future<Response> fetchTransport(Request request, RequestOptions options) async {
 
     throw OxyNetworkException(error.toString(), cause: error, trace: trace);
   }
+}
+
+WebRequestBodyMode _requestBodyMode(RequestOptions options) {
+  final rawValue = options.extra[webRequestBodyModeExtraKey];
+  if (rawValue is String) {
+    return WebRequestBodyMode.values.byName(rawValue);
+  }
+
+  return WebRequestBodyMode.streaming;
+}
+
+Future<Uint8List> _materializeRequestBody(Body requestBody) {
+  // Non-stream request bodies should align with native `fetch` semantics on
+  // web. Materializing these bodies avoids accidentally opting into browser
+  // request streaming, which requires `duplex: 'half'` and rejects HTTP/1.x.
+  return requestBody.bytes();
 }
 
 void _bindAbort(AbortController controller, RequestOptions options) {

--- a/lib/src/_internal/transport.web.dart
+++ b/lib/src/_internal/transport.web.dart
@@ -179,8 +179,13 @@ Future<Response> fetchTransport(Request request, RequestOptions options) async {
 
 WebRequestBodyMode _requestBodyMode(RequestOptions options) {
   final rawValue = options.extra[webRequestBodyModeExtraKey];
-  if (rawValue is String) {
+  if (rawValue is String &&
+      WebRequestBodyMode.values.any((mode) => mode.name == rawValue)) {
     return WebRequestBodyMode.values.byName(rawValue);
+  }
+
+  if (rawValue != null) {
+    return WebRequestBodyMode.buffered;
   }
 
   return WebRequestBodyMode.streaming;

--- a/lib/src/_internal/web_request_body_mode.dart
+++ b/lib/src/_internal/web_request_body_mode.dart
@@ -1,0 +1,3 @@
+const String webRequestBodyModeExtraKey = '__oxy.web_request_body_mode';
+
+enum WebRequestBodyMode { buffered, streaming }

--- a/lib/src/oxy.dart
+++ b/lib/src/oxy.dart
@@ -40,7 +40,9 @@ class Oxy {
   }
 
   Future<Response> send(Request request, {RequestOptions? options}) async {
-    final resolvedOptions = _resolveOptions(options);
+    final resolvedOptions = _resolveOptions(
+      _ensureWebRequestBodyMode(options, request),
+    );
     final signal = resolvedOptions.signal;
     if (signal?.aborted ?? false) {
       throw OxyCancelledException(reason: signal?.reason);
@@ -92,10 +94,7 @@ class Oxy {
 
     final nextOptions = (options ?? const RequestOptions()).copyWith(
       query: query,
-      extra: _withWebRequestBodyMode(
-        options?.extra ?? const {},
-        requestBody,
-      ),
+      extra: _withWebRequestBodyMode(options?.extra ?? const {}, requestBody),
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
     );
@@ -1049,6 +1048,28 @@ class Oxy {
           ? WebRequestBodyMode.streaming.name
           : WebRequestBodyMode.buffered.name,
     };
+  }
+
+  static RequestOptions? _ensureWebRequestBodyMode(
+    RequestOptions? options,
+    Request request,
+  ) {
+    final body = request.body;
+    final extra = options?.extra ?? const <String, Object?>{};
+    if (body == null || extra.containsKey(webRequestBodyModeExtraKey)) {
+      return options;
+    }
+
+    return (options ?? const RequestOptions()).copyWith(
+      extra: <String, Object?>{
+        ...extra,
+        // Manually-constructed Request instances do not preserve whether the
+        // original body came from a String/bytes source or a Dart stream.
+        // Defaulting to buffered matches native browser fetch for common
+        // request bodies without overriding explicit streaming metadata.
+        webRequestBodyModeExtraKey: WebRequestBodyMode.buffered.name,
+      },
+    );
   }
 
   Uri _resolveUrl(Uri url) {

--- a/lib/src/oxy.dart
+++ b/lib/src/oxy.dart
@@ -15,6 +15,7 @@ import '_internal/transport.stub.dart'
     if (dart.library.io) '_internal/transport.native.dart'
     if (dart.library.js_interop) '_internal/transport.web.dart'
     as transport;
+import '_internal/web_request_body_mode.dart';
 
 class Oxy {
   Oxy([OxyConfig? config]) : _config = config ?? const OxyConfig();
@@ -91,6 +92,10 @@ class Oxy {
 
     final nextOptions = (options ?? const RequestOptions()).copyWith(
       query: query,
+      extra: _withWebRequestBodyMode(
+        options?.extra ?? const {},
+        requestBody,
+      ),
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
     );
@@ -1028,6 +1033,22 @@ class Oxy {
     }
 
     return body;
+  }
+
+  static Map<String, Object?> _withWebRequestBodyMode(
+    Map<String, Object?> extra,
+    Object? body,
+  ) {
+    if (body == null) {
+      return extra;
+    }
+
+    return <String, Object?>{
+      ...extra,
+      webRequestBodyModeExtraKey: body is Stream<List<int>>
+          ? WebRequestBodyMode.streaming.name
+          : WebRequestBodyMode.buffered.name,
+    };
   }
 
   Uri _resolveUrl(Uri url) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,4 +23,5 @@ dependencies:
 
 dev_dependencies:
   lints: ^6.0.0
+  stream_channel: ^2.1.2
   test: ^1.26.2

--- a/test/oxy_client_browser_test.dart
+++ b/test/oxy_client_browser_test.dart
@@ -172,6 +172,32 @@ void main() {
       });
     });
 
+    test('manual send preserves browser request body mode metadata', () async {
+      final client = Oxy();
+      final response = await client.send(
+        Request(
+          echoUri.toString(),
+          RequestInit(
+            method: HttpMethod.post,
+            headers: Headers({'content-type': 'application/json'}),
+            body: jsonEncode({
+              'name': 'Manual Send',
+              'email': 'manual-send@spry.dev',
+            }),
+          ),
+        ),
+      );
+
+      expect(response.status, 200);
+      expect(await response.json<Map<String, Object?>>(), {
+        'method': 'POST',
+        'body': jsonEncode({
+          'name': 'Manual Send',
+          'email': 'manual-send@spry.dev',
+        }),
+      });
+    });
+
     test('reports send and receive progress on browser', () async {
       final client = Oxy();
       final sent = <TransferProgress>[];

--- a/test/oxy_client_browser_test.dart
+++ b/test/oxy_client_browser_test.dart
@@ -4,12 +4,66 @@ library;
 import 'dart:convert';
 
 import 'package:oxy/oxy.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
+
+extension on StreamChannel {
+  Future<int> get firstAsInt async => ((await stream.first) as num).toInt();
+}
 
 void main() {
   group('Oxy client (browser)', () {
+    late Uri echoUri;
     late String textUrl;
     late String jsonUrl;
+
+    setUpAll(() async {
+      final channel = spawnHybridCode(
+        r'''
+        import 'dart:convert';
+        import 'dart:io';
+
+        import 'package:stream_channel/stream_channel.dart';
+
+        Future<void> hybridMain(StreamChannel channel) async {
+          final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+
+          channel.sink.add(server.port);
+
+          await for (final request in server) {
+            request.response.headers
+              ..set('access-control-allow-origin', '*')
+              ..set('access-control-allow-headers', 'content-type')
+              ..set('access-control-allow-methods', 'POST, OPTIONS');
+
+            if (request.method == 'OPTIONS') {
+              request.response
+                ..statusCode = HttpStatus.noContent
+                ..close();
+              continue;
+            }
+
+            if (request.uri.path != '/echo') {
+              request.response
+                ..statusCode = HttpStatus.notFound
+                ..close();
+              continue;
+            }
+
+            final body = await utf8.decodeStream(request);
+            request.response.headers.contentType = ContentType.json;
+            request.response.write(
+              jsonEncode({'method': request.method, 'body': body}),
+            );
+            await request.response.close();
+          }
+        }
+        ''',
+        stayAlive: true,
+      );
+
+      echoUri = Uri.parse('http://127.0.0.1:${await channel.firstAsInt}/echo');
+    });
 
     setUp(() {
       textUrl = Uri.dataFromString(
@@ -66,6 +120,30 @@ void main() {
 
       expect(result.isFailure, isTrue);
       expect(result.error, isA<OxyCancelledException>());
+    });
+
+    test('posts JSON body to HTTP/1.1 endpoint', () async {
+      final client = Oxy();
+      final response = await client.post(
+        echoUri.toString(),
+        headers: Headers({'content-type': 'application/json'}),
+        body: jsonEncode({
+          'name': 'Browser Repro',
+          'email': 'browser-repro@spry.dev',
+        }),
+      );
+
+      expect(response.status, 200);
+      expect(
+        await response.json<Map<String, Object?>>(),
+        {
+          'method': 'POST',
+          'body': jsonEncode({
+            'name': 'Browser Repro',
+            'email': 'browser-repro@spry.dev',
+          }),
+        },
+      );
     });
 
     test('reports send and receive progress on browser', () async {

--- a/test/oxy_client_browser_test.dart
+++ b/test/oxy_client_browser_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 
 import 'package:oxy/oxy.dart';
+import 'package:oxy/src/_internal/web_request_body_mode.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -18,8 +19,7 @@ void main() {
     late String jsonUrl;
 
     setUpAll(() async {
-      final channel = spawnHybridCode(
-        r'''
+      final channel = spawnHybridCode(r'''
         import 'dart:convert';
         import 'dart:io';
 
@@ -58,9 +58,7 @@ void main() {
             await request.response.close();
           }
         }
-        ''',
-        stayAlive: true,
-      );
+        ''', stayAlive: true);
 
       echoUri = Uri.parse('http://127.0.0.1:${await channel.firstAsInt}/echo');
     });
@@ -134,16 +132,44 @@ void main() {
       );
 
       expect(response.status, 200);
-      expect(
-        await response.json<Map<String, Object?>>(),
-        {
-          'method': 'POST',
-          'body': jsonEncode({
-            'name': 'Browser Repro',
-            'email': 'browser-repro@spry.dev',
-          }),
-        },
+      expect(await response.json<Map<String, Object?>>(), {
+        'method': 'POST',
+        'body': jsonEncode({
+          'name': 'Browser Repro',
+          'email': 'browser-repro@spry.dev',
+        }),
+      });
+    });
+
+    test('ignores invalid internal web request body mode metadata', () async {
+      final client = Oxy();
+      final response = await client.send(
+        Request(
+          echoUri.toString(),
+          RequestInit(
+            method: HttpMethod.post,
+            headers: Headers({'content-type': 'application/json'}),
+            body: jsonEncode({
+              'name': 'Invalid Metadata',
+              'email': 'invalid-metadata@spry.dev',
+            }),
+          ),
+        ),
+        options: const RequestOptions(
+          extra: <String, Object?>{
+            webRequestBodyModeExtraKey: 'not-a-valid-mode',
+          },
+        ),
       );
+
+      expect(response.status, 200);
+      expect(await response.json<Map<String, Object?>>(), {
+        'method': 'POST',
+        'body': jsonEncode({
+          'name': 'Invalid Metadata',
+          'email': 'invalid-metadata@spry.dev',
+        }),
+      });
     });
 
     test('reports send and receive progress on browser', () async {


### PR DESCRIPTION
Resolves #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable web request body handling with automatic buffered vs. streaming modes and improved transport behavior for each mode.

* **Tests**
  * Added browser-based integration tests that spin up a local test server to verify POST/echo behavior and body-mode handling.

* **Chores**
  * Added a development dependency to support new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->