### PR TITLE
docs: add low-friction fetch quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ dependencies:
 
 ## Quick Start
 
+Use `fetch(...)` for one-off requests:
+
+```dart
+import 'package:oxy/oxy.dart';
+
+Future<void> main() async {
+  final response = await fetch('https://httpbin.org/get');
+  final payload = await response.json<Map<String, Object?>>();
+
+  print(payload['url']);
+}
+```
+
+Create a `Client` when you want to share a base URL, headers, policies,
+middleware, or native keep-alive connections across requests:
+
 ```dart
 import 'package:oxy/oxy.dart';
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,22 @@ dependencies:
 
 ## Quick Start
 
-Use `fetch(...)` for one-off requests:
+Use `fetch(...)` for one-off requests. In short-lived native scripts, close the
+shared `client` when the process is done:
 
 ```dart
 import 'package:oxy/oxy.dart';
 
 Future<void> main() async {
-  final response = await fetch('https://httpbin.org/get');
-  final payload = await response.json<Map<String, Object?>>();
+  try {
+    final response = await fetch('https://httpbin.org/get');
+    final payload = await response.json<Map<String, Object?>>();
 
-  print(payload['url']);
+    print(payload['url']);
+  } finally {
+    // Close the shared client when a short-lived script is done.
+    await client.close();
+  }
 }
 ```
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,15 +1,8 @@
 import 'package:oxy/oxy.dart';
 
 Future<void> main() async {
-  final client = Client(
-    ClientOptions(baseUrl: Uri.parse('https://httpbin.org')),
-  );
+  final response = await fetch('https://httpbin.org/get');
+  final payload = await response.json<Map<String, Object?>>();
 
-  try {
-    final response = await client.post('/post', json: {'name': 'oxy'});
-    final payload = await response.json<Map<String, Object?>>();
-    print(payload['json']);
-  } finally {
-    await client.close();
-  }
+  print(payload['url']);
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,8 +1,13 @@
 import 'package:oxy/oxy.dart';
 
 Future<void> main() async {
-  final response = await fetch('https://httpbin.org/get');
-  final payload = await response.json<Map<String, Object?>>();
+  try {
+    final response = await fetch('https://httpbin.org/get');
+    final payload = await response.json<Map<String, Object?>>();
 
-  print(payload['url']);
+    print(payload['url']);
+  } finally {
+    // Close the shared client when a short-lived script is done.
+    await client.close();
+  }
 }


### PR DESCRIPTION
## Summary

- Add a top-level `fetch(...)` Quick Start for one-off requests.
- Keep the reusable `Client` example as the production path for shared base URLs, policies, middleware, and keep-alive connections.
- Simplify `example/main.dart` so pub.dev shows the lowest-friction request path first.

## Type

documentation

## Validation

- `dart analyze`
- `dart test`
- `dart run example/main.dart`

Closes #37