### PR TITLE
ci: add analyzer and publish dry-run gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
+      - run: dart analyze
       - run: dart test -p vm
       - run: dart test -p node
       - run: dart test -p chrome
+      - run: dart pub publish --dry-run


### PR DESCRIPTION
## Summary

- Add `dart analyze` to CI so analyzer issues fail the workflow before tests complete.
- Add `dart pub publish --dry-run` to CI so package publishing health is checked before release work.
- Keep the existing VM, node, and chrome test coverage intact.

## Type

ci

## Validation

- `git diff --check`
- `dart analyze`
- `dart test`
- `dart pub publish --dry-run` reported 0 warnings

Closes #40