### PR TITLE
docs: add stability and roadmap guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ Another package may fit better when:
 - Request bodies carry replayability metadata, so one-shot streams are not retried accidentally.
 - Middleware runs through a clear pipeline: application middleware once per logical request, network middleware once per attempt.
 
+## Stability and Roadmap
+
+Oxy is still pre-1.0, so minor releases may include breaking changes while the
+package hardens. The current direction is the intended stable model: `Client`,
+`Request`, `Response`, `Headers`, `Body`, policy types, middleware, typed
+request errors, `Result`, and the single-package native/Web transport layer.
+
+Breaking changes before 1.0 should be deliberate, documented in the changelog,
+and focused on making that model simpler or safer. Oxy does not plan to rename
+the core public types to branded alternatives or split native/Web support into
+adapter packages.
+
+Before 1.0, the main confidence-building work is:
+
+- complete API docs and cookbook examples for common client patterns;
+- keep CI and release checks strict, including analyzer and publish dry-run
+  gates;
+- refactor `Client` internals without changing the public API shape;
+- continue tightening native/Web behavior parity around policies, redirects,
+  streaming, and body replayability.
+
 ## Installation
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add a short README section documenting Oxy's pre-1.0 stability policy.
- Clarify that the current `Client` / `Request` / `Response` / policy / middleware / typed-error model is the intended stable direction.
- Add a lightweight roadmap focused on docs, CI/release quality gates, internal refactoring without public API churn, and native/Web behavior parity.

## Type

documentation

## Validation

- `git diff --check`
- `dart analyze`
- `dart test`
- `dart pub publish --dry-run` on a clean worktree reported 0 warnings

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Stability and Roadmap" section to README outlining pre-1.0 status, breaking change policy, core commitments around public API stability and multi-platform support, and near-term initiatives including API documentation, release processes, and cross-platform consistency improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->