### PR TITLE
refactor: make response bodies immutable

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -22,6 +22,13 @@ import 'transport/transport.dart';
 
 const Object _jsonOmitted = Object();
 
+final class _StatusBodyPreview {
+  const _StatusBodyPreview({required this.response, this.bodyPreview});
+
+  final Response response;
+  final String? bodyPreview;
+}
+
 final class Client {
   Client([ClientOptions options = const ClientOptions()])
     : options = options,
@@ -586,9 +593,13 @@ final class Client {
         RequestEventType.statusFailed,
         request: request,
         attempt: context.attempt,
-        response: response,
+        response: preview.response,
       );
-      throw StatusError(response, request: request, bodyPreview: preview);
+      throw StatusError(
+        preview.response,
+        request: request,
+        bodyPreview: preview.bodyPreview,
+      );
     }
 
     return response;
@@ -823,12 +834,12 @@ final class Client {
             RequestEventType.statusFailed,
             request: attemptRequest,
             attempt: attempt,
-            response: response,
+            response: preview.response,
           );
           throw StatusError(
-            response,
+            preview.response,
             request: attemptRequest,
-            bodyPreview: preview,
+            bodyPreview: preview.bodyPreview,
           );
         }
 
@@ -1240,11 +1251,14 @@ final class Client {
     );
   }
 
-  Future<String?> _previewStatusBody(Response response, Context context) async {
+  Future<_StatusBodyPreview> _previewStatusBody(
+    Response response,
+    Context context,
+  ) async {
     final limit = context.clientOptions.errorBodyPreviewLimit;
     final body = response.body;
     if (limit <= 0 || body == null) {
-      return null;
+      return _StatusBodyPreview(response: response);
     }
 
     try {
@@ -1257,19 +1271,33 @@ final class Client {
         chunks.add(chunk);
         builder.add(chunk);
         if (builder.length > limit) {
-          response.body = ResponseBody.stream(
-            _restorePreviewStream(chunks, iterator),
-            contentLength: body.contentLength,
+          if (body.replayable) {
+            await iterator.cancel();
+            return _StatusBodyPreview(response: response);
+          }
+          return _StatusBodyPreview(
+            response: response.copyWith(
+              body: ResponseBody.stream(
+                _restorePreviewStream(chunks, iterator),
+                contentLength: body.contentLength,
+              ),
+            ),
           );
-          return null;
         }
       }
 
       final data = builder.takeBytes();
-      response.body = ResponseBody.fromBytes(data);
-      return utf8.decode(data);
+      final next = response.copyWith(body: ResponseBody.fromBytes(data));
+      try {
+        return _StatusBodyPreview(
+          response: next,
+          bodyPreview: utf8.decode(data),
+        );
+      } catch (_) {
+        return _StatusBodyPreview(response: next);
+      }
     } catch (_) {
-      return null;
+      return _StatusBodyPreview(response: response);
     }
   }
 

--- a/lib/src/core/response.dart
+++ b/lib/src/core/response.dart
@@ -81,7 +81,7 @@ final class Response {
   final Uri url;
   final bool redirected;
   final bool fromCache;
-  ResponseBody? body;
+  final ResponseBody? body;
 
   bool get ok => status >= 200 && status <= 299;
 

--- a/lib/src/features/cache.dart
+++ b/lib/src/features/cache.dart
@@ -184,22 +184,23 @@ final class CacheMiddleware implements Middleware {
       return response;
     }
 
-    final buffered = await _tryBuffer(request, response);
-    if (buffered == null) {
+    final bufferResult = await _tryBuffer(request, response);
+    final cacheResponse = bufferResult.cacheResponse;
+    if (cacheResponse == null) {
       await _store.delete(key);
-      return response;
+      return bufferResult.response;
     }
 
     await _store.write(
       key,
       CachedResponse(
-        response: buffered,
+        response: cacheResponse,
         storedAt: receivedAt,
         expiresAt: expiresAt,
         etag: etag,
       ),
     );
-    return buffered.copyWith(fromCache: false);
+    return cacheResponse.copyWith(fromCache: false);
   }
 
   static String _defaultCacheKeyBuilder(Request request, Context _) {
@@ -430,15 +431,18 @@ final class CacheMiddleware implements Middleware {
         .any((value) => value.trim() == '*');
   }
 
-  Future<Response?> _tryBuffer(Request request, Response response) async {
+  Future<_CacheBufferResult> _tryBuffer(
+    Request request,
+    Response response,
+  ) async {
     final body = response.body;
     if (body == null) {
-      return response;
+      return _CacheBufferResult(response: response, cacheResponse: response);
     }
 
     final contentLength = body.contentLength;
     if (contentLength != null && contentLength > maxEntryBytes) {
-      return null;
+      return _CacheBufferResult(response: response);
     }
 
     final iterator = StreamIterator<Uint8List>(body.open());
@@ -450,16 +454,24 @@ final class CacheMiddleware implements Middleware {
         chunks.add(chunk);
         builder.add(chunk);
         if (builder.length > maxEntryBytes) {
-          response.body = ResponseBody.stream(
-            _restoreBody(chunks, iterator),
-            contentLength: body.contentLength,
+          if (body.replayable) {
+            await iterator.cancel();
+            return _CacheBufferResult(response: response);
+          }
+          return _CacheBufferResult(
+            response: response.copyWith(
+              body: ResponseBody.stream(
+                _restoreBody(chunks, iterator),
+                contentLength: body.contentLength,
+              ),
+            ),
           );
-          return null;
         }
       }
-      return response.copyWith(
+      final buffered = response.copyWith(
         body: ResponseBody.fromBytes(builder.takeBytes()),
       );
+      return _CacheBufferResult(response: buffered, cacheResponse: buffered);
     } catch (error, trace) {
       if (error is RequestError) {
         rethrow;
@@ -489,6 +501,13 @@ final class CacheMiddleware implements Middleware {
       await iterator.cancel();
     }
   }
+}
+
+final class _CacheBufferResult {
+  const _CacheBufferResult({required this.response, this.cacheResponse});
+
+  final Response response;
+  final Response? cacheResponse;
 }
 
 const Set<String> _cacheKeyIgnoredHeaders = <String>{

--- a/test/policy_test.dart
+++ b/test/policy_test.dart
@@ -47,6 +47,32 @@ void main() {
     }
   });
 
+  test('status policy restores over-limit preview bodies', () async {
+    final payload = Uint8List.fromList('0123456789'.codeUnits);
+    final client = Client(
+      ClientOptions(
+        errorBodyPreviewLimit: 4,
+        transport: MockTransport((request, context) async {
+          return Response.stream(
+            Stream<List<int>>.fromIterable([
+              payload.sublist(0, 3),
+              payload.sublist(3),
+            ]),
+            status: 400,
+          );
+        }),
+      ),
+    );
+
+    try {
+      await client.get('https://example.com/large-error');
+      fail('Expected StatusError.');
+    } on StatusError catch (error) {
+      expect(error.bodyPreview, isNull);
+      expect(await error.statusResponse.bytes(), orderedEquals(payload));
+    }
+  });
+
   test('status policy can return non-2xx responses', () async {
     final client = Client(
       ClientOptions(


### PR DESCRIPTION
## Summary
- Make `Response.body` final so response bodies are not replaced in place.
- Return restored responses from status-error body preview handling instead of mutating the existing response.
- Carry restored cache responses through oversized buffering paths without writing back to `response.body`.
- Add a regression test for over-limit status previews preserving the thrown response body.

Closes #42

## Validation
- `dart analyze`
- `dart test test/policy_test.dart`
- `dart test test/features_test.dart`
- `dart test`
- `dart pub publish --dry-run`