### PR TITLE
docs: add API docs and cookbook examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Removed middleware presets; compose middleware explicitly from the built-in
   middleware types instead.
 
+### Added
+
+- Added public API Dartdoc, a cookbook, and checked examples for reusable API
+  clients, policies, no-throw flows, middleware, testing, and body
+  replayability.
+
 ## 0.3.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Future<void> main() async {
 }
 ```
 
+## Cookbook
+
+For copyable examples that cover reusable API clients, policies, no-throw
+`Result` flows, middleware composition, testing, and body replayability, see the
+[Oxy Cookbook](https://github.com/medz/oxy/blob/main/doc/cookbook.md). The
+linked examples under `example/` are checked by `dart analyze`.
+
 ## API Client Pattern
 
 Oxy is designed to sit behind a small package or app-specific API client:

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1,0 +1,148 @@
+# Oxy Cookbook
+
+This cookbook shows the common paths that are useful when Oxy sits inside an
+application or reusable API client. The examples are also available as Dart
+files under `example/`, so `dart analyze` checks that they keep compiling.
+
+## Build a Reusable API Client
+
+Create one long-lived `Client` with a base URL and policies, then hide it behind
+small domain methods. Decode at the edge of that client instead of spreading
+JSON casts across the app.
+
+See [`example/api_client.dart`](../example/api_client.dart).
+
+```dart
+final client = Client(
+  ClientOptions(
+    baseUrl: Uri.parse('https://api.example.com'),
+    timeoutPolicy: const TimeoutPolicy(total: Duration(seconds: 10)),
+    retryPolicy: const RetryPolicy(maxRetries: 2),
+  ),
+);
+
+final user = await client.decode<User>(
+  'GET',
+  '/users/42',
+  decoder: User.fromJson,
+);
+```
+
+Close clients that own their transport:
+
+```dart
+try {
+  // use the client
+} finally {
+  await client.close();
+}
+```
+
+## Configure Policies Per Client or Request
+
+Client options define the normal behavior. `RequestOptions` can override that
+behavior for one call.
+
+See [`example/policies.dart`](../example/policies.dart).
+
+```dart
+final client = Client(
+  ClientOptions(
+    timeoutPolicy: const TimeoutPolicy(total: Duration(seconds: 20)),
+    retryPolicy: const RetryPolicy(maxRetries: 1),
+    redirectPolicy: RedirectPolicy.manual,
+  ),
+);
+
+final response = await client.get(
+  '/missing',
+  options: const RequestOptions(statusPolicy: StatusPolicy.returnResponse),
+);
+```
+
+Use `StatusPolicy.returnResponse` when non-2xx responses are expected data. Keep
+the default `StatusPolicy.throwOnError` when non-2xx responses should fail fast
+with `StatusError`.
+
+## Use Result for No-Throw Flows
+
+Use `Result` when a caller should branch on success or failure without a
+`try`/`catch`.
+
+See [`example/no_throw_result.dart`](../example/no_throw_result.dart).
+
+```dart
+final result = await client.requestResult('GET', '/health');
+
+final message = result.fold(
+  onSuccess: (response) => 'status ${response.status}',
+  onFailure: (error, trace) => 'failed with $error',
+);
+```
+
+`Result.getOrThrow()` restores the exception path when a later layer wants to
+rethrow the captured failure with its original stack trace.
+
+## Compose Middleware
+
+Application middleware runs once for the logical request. Network middleware
+runs for every network attempt. Most application clients should start with
+application middleware and only use network middleware when they need
+attempt-level behavior.
+
+See [`example/middleware_stack.dart`](../example/middleware_stack.dart).
+
+```dart
+final client = Client(
+  ClientOptions(
+    middleware: [
+      RequestIdMiddleware(),
+      AuthMiddleware.staticToken('secret'),
+      CookieMiddleware(MemoryCookieJar()),
+      CacheMiddleware(),
+      LoggingMiddleware(),
+    ],
+  ),
+);
+```
+
+`CookieMiddleware` is for native and test transports. Browser requests already
+use browser cookie handling, so the middleware is a no-op on Web.
+
+## Test with MockTransport
+
+`MockTransport` lets tests exercise the real `Client` pipeline without opening a
+socket.
+
+```dart
+final transport = MockTransport((request, context) async {
+  if (request.headers.get('authorization') != 'Bearer secret') {
+    throw StateError('missing authorization');
+  }
+  return Response.json({'ok': true});
+});
+
+final client = Client(ClientOptions(transport: transport));
+```
+
+`transport.requests` records the prepared requests, which is useful for checking
+headers, URLs, methods, and body behavior.
+
+## Handle Body Replayability
+
+Oxy tracks whether request and response bodies are replayable.
+
+- `String`, `List<int>`, `Uint8List`, JSON bodies, `Blob`, `FormData`, and
+  `URLSearchParams` are replayable.
+- Raw `Stream<List<int>>` bodies are one-shot.
+- One-shot request bodies are not retried implicitly.
+- Use `Response.buffered()` when later code needs to read a streaming response
+  body more than once.
+
+```dart
+final response = await client.get('/report');
+final buffered = await response.buffered(maxBytes: 1024 * 1024);
+
+print(await buffered.text());
+print(await buffered.text());
+```

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -98,16 +98,18 @@ final client = Client(
     middleware: [
       RequestIdMiddleware(),
       AuthMiddleware.staticToken('secret'),
-      CookieMiddleware(MemoryCookieJar()),
       CacheMiddleware(),
       LoggingMiddleware(),
     ],
+    networkMiddleware: [CookieMiddleware(MemoryCookieJar())],
   ),
 );
 ```
 
-`CookieMiddleware` is for native and test transports. Browser requests already
-use browser cookie handling, so the middleware is a no-op on Web.
+`CookieMiddleware` belongs in network middleware so redirects and retries can
+store cookies between attempts. It is for native and test transports. Browser
+requests already use browser cookie handling, so the middleware is a no-op on
+Web.
 
 ## Test with MockTransport
 

--- a/example/api_client.dart
+++ b/example/api_client.dart
@@ -1,0 +1,45 @@
+import 'package:oxy/oxy.dart';
+import 'package:oxy/testing.dart';
+
+final class UsersApi {
+  UsersApi(this._client);
+
+  final Client _client;
+
+  Future<User> getUser(String id) {
+    return _client.decode<User>('GET', '/users/$id', decoder: User.fromJson);
+  }
+}
+
+final class User {
+  const User({required this.id, required this.name});
+
+  final String id;
+  final String name;
+
+  static User fromJson(Object? value) {
+    final json = value as Map<String, Object?>;
+    return User(id: json['id'] as String, name: json['name'] as String);
+  }
+}
+
+Future<void> main() async {
+  final client = Client(
+    ClientOptions(
+      baseUrl: Uri.parse('https://api.example.com'),
+      timeoutPolicy: const TimeoutPolicy(total: Duration(seconds: 10)),
+      retryPolicy: const RetryPolicy(maxRetries: 2),
+      transport: MockTransport((request, context) async {
+        return Response.json({'id': '42', 'name': 'Ada'});
+      }),
+    ),
+  );
+
+  try {
+    final users = UsersApi(client);
+    final user = await users.getUser('42');
+    print(user.name);
+  } finally {
+    await client.close();
+  }
+}

--- a/example/middleware_stack.dart
+++ b/example/middleware_stack.dart
@@ -1,0 +1,42 @@
+import 'package:oxy/oxy.dart';
+import 'package:oxy/testing.dart';
+
+Future<void> main() async {
+  final logs = <String>[];
+  final client = Client(
+    ClientOptions(
+      baseUrl: Uri.parse('https://api.example.com'),
+      middleware: [
+        RequestIdMiddleware(requestIdProvider: (_, _) => 'request-1'),
+        AuthMiddleware.staticToken('secret'),
+        CookieMiddleware(MemoryCookieJar()),
+        CacheMiddleware(
+          keyBuilder: (request, context) {
+            return '${request.method} ${request.uri}';
+          },
+        ),
+        LoggingMiddleware(printer: logs.add),
+      ],
+      transport: MockTransport((request, context) async {
+        return Response.json(
+          {'ok': true},
+          headers: {
+            'cache-control': 'max-age=60',
+            'set-cookie': 'sid=abc; Path=/',
+          },
+        );
+      }),
+    ),
+  );
+
+  try {
+    final first = await client.get('/profile');
+    final second = await client.get('/profile');
+
+    print(first.fromCache);
+    print(second.fromCache);
+    print(logs.length);
+  } finally {
+    await client.close();
+  }
+}

--- a/example/middleware_stack.dart
+++ b/example/middleware_stack.dart
@@ -9,7 +9,6 @@ Future<void> main() async {
       middleware: [
         RequestIdMiddleware(requestIdProvider: (_, _) => 'request-1'),
         AuthMiddleware.staticToken('secret'),
-        CookieMiddleware(MemoryCookieJar()),
         CacheMiddleware(
           keyBuilder: (request, context) {
             return '${request.method} ${request.uri}';
@@ -17,6 +16,7 @@ Future<void> main() async {
         ),
         LoggingMiddleware(printer: logs.add),
       ],
+      networkMiddleware: [CookieMiddleware(MemoryCookieJar())],
       transport: MockTransport((request, context) async {
         return Response.json(
           {'ok': true},

--- a/example/no_throw_result.dart
+++ b/example/no_throw_result.dart
@@ -1,0 +1,29 @@
+import 'package:oxy/oxy.dart';
+import 'package:oxy/testing.dart';
+
+Future<void> main() async {
+  final client = Client(
+    ClientOptions(
+      baseUrl: Uri.parse('https://api.example.com'),
+      transport: MockTransport((request, context) async {
+        return Response.text(
+          'bad request',
+          status: 400,
+          statusText: 'Bad Request',
+        );
+      }),
+    ),
+  );
+
+  try {
+    final result = await client.requestResult('GET', '/health');
+
+    final message = result.fold(
+      onSuccess: (response) => 'status ${response.status}',
+      onFailure: (error, trace) => 'failed with $error',
+    );
+    print(message);
+  } finally {
+    await client.close();
+  }
+}

--- a/example/policies.dart
+++ b/example/policies.dart
@@ -1,0 +1,36 @@
+import 'package:oxy/oxy.dart';
+import 'package:oxy/testing.dart';
+
+Future<void> main() async {
+  var calls = 0;
+  final client = Client(
+    ClientOptions(
+      baseUrl: Uri.parse('https://api.example.com'),
+      timeoutPolicy: const TimeoutPolicy(total: Duration(seconds: 20)),
+      retryPolicy: const RetryPolicy(maxRetries: 1, baseDelay: Duration.zero),
+      redirectPolicy: RedirectPolicy.manual,
+      transport: MockTransport((request, context) async {
+        if (request.uri.path == '/flaky' && calls++ == 0) {
+          return Response.text('try again', status: 503);
+        }
+        if (request.uri.path == '/missing') {
+          return Response.text('missing', status: 404);
+        }
+        return Response.text('ok');
+      }),
+    ),
+  );
+
+  try {
+    final retried = await client.get('/flaky');
+    print(await retried.text());
+
+    final expected404 = await client.get(
+      '/missing',
+      options: const RequestOptions(statusPolicy: StatusPolicy.returnResponse),
+    );
+    print(expected404.status);
+  } finally {
+    await client.close();
+  }
+}

--- a/lib/oxy.dart
+++ b/lib/oxy.dart
@@ -1,3 +1,26 @@
+/// A policy-first HTTP client for Dart and Flutter applications.
+///
+/// Import this library when you want to send one-off requests with [fetch],
+/// build a long-lived [Client] for a reusable API client, configure retry and
+/// timeout policies, compose middleware, or test network code with
+/// `package:oxy/testing.dart`.
+///
+/// ```dart
+/// import 'package:oxy/oxy.dart';
+///
+/// Future<void> main() async {
+///   final client = Client(
+///     ClientOptions(baseUrl: Uri.parse('https://api.example.com')),
+///   );
+///
+///   try {
+///     final response = await client.get('/health');
+///     print(response.status);
+///   } finally {
+///     await client.close();
+///   }
+/// }
+/// ```
 library;
 
 export 'package:ht/ht.dart' show Blob, FormData, Multipart, URLSearchParams;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -29,6 +29,27 @@ final class _StatusBodyPreview {
   final String? bodyPreview;
 }
 
+/// A reusable HTTP client with shared options, middleware, and transport state.
+///
+/// Create a [Client] when requests should share a base URL, default headers,
+/// retry and timeout policies, middleware, or native keep-alive connections.
+/// For one-off requests, use [fetch].
+///
+/// ```dart
+/// final client = Client(
+///   ClientOptions(baseUrl: Uri.parse('https://api.example.com')),
+/// );
+///
+/// try {
+///   final response = await client.get('/users/1');
+///   print(await response.json<Map<String, Object?>>());
+/// } finally {
+///   await client.close();
+/// }
+/// ```
+///
+/// A client owns its default transport unless [ClientOptions.transport] is set.
+/// Call [close] when a long-lived client is no longer needed.
 final class Client {
   Client([ClientOptions options = const ClientOptions()])
     : options = options,
@@ -37,16 +58,23 @@ final class Client {
           options.transport ??
           createDefaultTransport(keepAlive: options.keepAlive);
 
+  /// The defaults applied to requests sent by this client.
   final ClientOptions options;
   final Transport _transport;
   final bool _ownsTransport;
   final Random _random = Random();
   bool _closed = false;
 
+  /// The transport used after request resolution, policies, and middleware.
   Transport get transport => _transport;
 
+  /// Creates a new client with [next] as its options.
   Client withOptions(ClientOptions next) => Client(next);
 
+  /// Creates a new client with additional application [middleware].
+  ///
+  /// When [replace] is `true`, [middleware] replaces the existing application
+  /// middleware list instead of being appended to it.
   Client withMiddleware(List<Middleware> middleware, {bool replace = false}) {
     return Client(
       options.copyWith(
@@ -57,6 +85,11 @@ final class Client {
     );
   }
 
+  /// Closes the client-owned transport.
+  ///
+  /// This method is idempotent. It only closes the transport that Oxy created
+  /// for this client; a custom [ClientOptions.transport] remains owned by the
+  /// caller.
   Future<void> close() async {
     if (_closed) {
       return;
@@ -67,6 +100,14 @@ final class Client {
     }
   }
 
+  /// Sends a prepared [request].
+  ///
+  /// The request is resolved against [ClientOptions.baseUrl], merged with
+  /// default headers and [options], then passed through middleware, retry,
+  /// redirect, timeout, and status policies.
+  ///
+  /// Throws a [RequestError] subtype for network, timeout, status, retry,
+  /// decode, body, and middleware failures.
   Future<Response> send(Request request, {RequestOptions? options}) async {
     if (_closed) {
       throw NetworkError('Client is closed.', request: request);
@@ -222,6 +263,9 @@ final class Client {
         policy.read != null;
   }
 
+  /// Sends [request] and captures success or failure in a [Result].
+  ///
+  /// This is the no-throw form of [send].
   Future<Result<Response>> sendResult(
     Request request, {
     RequestOptions? options,
@@ -229,6 +273,12 @@ final class Client {
     return Result.capture(() => send(request, options: options));
   }
 
+  /// Sends a request built from a method and URL.
+  ///
+  /// [url] can be a [String] or [Uri]. Relative URLs are resolved against
+  /// [ClientOptions.baseUrl]. Pass [json] to encode a JSON request body and set
+  /// the content type automatically, or pass [body] for raw body inputs accepted
+  /// by [Body.from].
   Future<Response> request(
     String method,
     Object url, {
@@ -264,6 +314,9 @@ final class Client {
     );
   }
 
+  /// Sends a request and captures success or failure in a [Result].
+  ///
+  /// This is the no-throw form of [request].
   Future<Result<Response>> requestResult(
     String method,
     Object url, {
@@ -290,6 +343,7 @@ final class Client {
     );
   }
 
+  /// Sends a `GET` request.
   Future<Response> get(
     Object url, {
     QueryMap? query,
@@ -307,6 +361,7 @@ final class Client {
     );
   }
 
+  /// Sends a `POST` request.
   Future<Response> post(
     Object url, {
     QueryMap? query,
@@ -330,6 +385,7 @@ final class Client {
     );
   }
 
+  /// Sends a `PUT` request.
   Future<Response> put(
     Object url, {
     QueryMap? query,
@@ -353,6 +409,7 @@ final class Client {
     );
   }
 
+  /// Sends a `PATCH` request.
   Future<Response> patch(
     Object url, {
     QueryMap? query,
@@ -376,6 +433,7 @@ final class Client {
     );
   }
 
+  /// Sends a `DELETE` request.
   Future<Response> delete(
     Object url, {
     QueryMap? query,
@@ -399,6 +457,7 @@ final class Client {
     );
   }
 
+  /// Sends a `HEAD` request.
   Future<Response> head(
     Object url, {
     QueryMap? query,
@@ -414,6 +473,10 @@ final class Client {
     );
   }
 
+  /// Sends an `OPTIONS` request.
+  ///
+  /// The method name avoids colliding with the [options] parameter used by the
+  /// other request helpers.
   Future<Response> optionsRequest(
     Object url, {
     QueryMap? query,
@@ -433,6 +496,11 @@ final class Client {
     );
   }
 
+  /// Sends a request and decodes the JSON response body.
+  ///
+  /// If [decoder] is provided, it maps the decoded JSON payload to [T].
+  /// Otherwise the decoded payload is cast to [T]. Decode and mapping failures
+  /// are reported as [DecodeError].
   Future<T> decode<T>(
     String method,
     Object url, {
@@ -1451,8 +1519,16 @@ final class _DownstreamError {
   final StackTrace trace;
 }
 
+/// The shared client used by [fetch] and [fetchResult].
+///
+/// This is useful for scripts and small programs. Call `client.close()` before
+/// a short-lived process exits if it used the shared client.
 final Client client = Client();
 
+/// Sends a one-off request with the shared [client].
+///
+/// For reusable API clients, prefer creating a [Client] with explicit
+/// [ClientOptions] and closing it when it is no longer needed.
 Future<Response> fetch(
   Object url, {
   String method = 'GET',
@@ -1477,6 +1553,9 @@ Future<Response> fetch(
   );
 }
 
+/// Sends a one-off request and captures success or failure in a [Result].
+///
+/// This is the no-throw form of [fetch].
 Future<Result<Response>> fetchResult(
   Object url, {
   String method = 'GET',

--- a/lib/src/core/abort.dart
+++ b/lib/src/core/abort.dart
@@ -1,12 +1,23 @@
 /// Cooperative cancellation signal used by requests, retry delays, and bodies.
 abstract interface class AbortSignal {
+  /// Creates a new, initially active cancellation signal.
   factory AbortSignal() = _AbortSignalImpl;
 
+  /// Whether [abort] has been called.
   bool get aborted;
+
+  /// The reason supplied to [abort], or `null`.
   Object? get reason;
 
+  /// Registers [callback] to run when the signal aborts.
+  ///
+  /// If the signal is already aborted, [callback] runs immediately.
   void onAbort(void Function() callback);
+
+  /// Throws [reason] if the signal is already aborted.
   void throwIfAborted();
+
+  /// Aborts the signal and notifies registered callbacks.
   void abort([Object? reason]);
 }
 

--- a/lib/src/core/attributes.dart
+++ b/lib/src/core/attributes.dart
@@ -1,30 +1,42 @@
+/// A typed key for values stored in [Attributes].
 final class AttributeKey<T extends Object> {
   const AttributeKey(this.name);
 
+  /// A human-readable key name for debugging.
   final String name;
 
   @override
   String toString() => 'AttributeKey<$T>($name)';
 }
 
+/// Immutable, typed metadata shared across request processing.
+///
+/// Attributes let middleware and transports exchange out-of-band data without
+/// adding public fields to `Request` or `Context`.
 final class Attributes {
   const Attributes([Map<AttributeKey<Object>, Object>? values])
     : _values = values ?? const <AttributeKey<Object>, Object>{};
 
   final Map<AttributeKey<Object>, Object> _values;
 
+  /// Whether no attributes are stored.
   bool get isEmpty => _values.isEmpty;
+
+  /// Whether at least one attribute is stored.
   bool get isNotEmpty => _values.isNotEmpty;
 
+  /// The value for [key], or `null` when absent or of a different type.
   T? get<T extends Object>(AttributeKey<T> key) {
     final value = _values[key as AttributeKey<Object>];
     return value is T ? value : null;
   }
 
+  /// Whether [key] is present.
   bool contains<T extends Object>(AttributeKey<T> key) {
     return _values.containsKey(key as AttributeKey<Object>);
   }
 
+  /// Returns a copy with [key] set to [value].
   Attributes set<T extends Object>(AttributeKey<T> key, T value) {
     return Attributes(<AttributeKey<Object>, Object>{
       ..._values,
@@ -32,12 +44,14 @@ final class Attributes {
     });
   }
 
+  /// Returns a copy without [key].
   Attributes remove<T extends Object>(AttributeKey<T> key) {
     final next = <AttributeKey<Object>, Object>{..._values};
     next.remove(key as AttributeKey<Object>);
     return Attributes(next);
   }
 
+  /// An unmodifiable map view of the stored attributes.
   Map<AttributeKey<Object>, Object> toMap() {
     return Map<AttributeKey<Object>, Object>.unmodifiable(_values);
   }

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -7,10 +7,18 @@ import 'package:ht/ht.dart' as ht;
 
 import 'errors.dart';
 
+/// The source kind of a request body.
 enum BodyKind { empty, bytes, text, json, form, multipart, file, stream }
 
+/// Opens a fresh byte stream for a replayable body.
 typedef BodyStreamFactory = Stream<List<int>> Function();
 
+/// A request body with replayability and metadata.
+///
+/// Oxy uses [replayable] to decide whether a request can be retried safely.
+/// Bodies created from bytes, text, JSON, forms, URL search params, blobs, and
+/// replayable stream factories are replayable. Bodies created from a raw
+/// `Stream<List<int>>` are one-shot.
 final class Body {
   static final Random _boundaryRandom = Random();
   static int _boundaryCounter = 0;
@@ -23,17 +31,26 @@ final class Body {
     this.contentType,
   }) : _open = open;
 
+  /// The original body source kind.
   final BodyKind kind;
+
+  /// Whether [open] can be called more than once.
   final bool replayable;
+
+  /// The known content length, or `null` when unknown.
   final int? contentLength;
+
+  /// The content type supplied by the body source, or `null`.
   final String? contentType;
   final BodyStreamFactory _open;
   bool _used = false;
 
+  /// Creates an empty replayable body.
   static Body empty() {
     return Body.fromBytes(const <int>[], kind: BodyKind.empty);
   }
 
+  /// Creates a replayable body from [bytes].
   static Body fromBytes(List<int> bytes, {BodyKind kind = BodyKind.bytes}) {
     final data = Uint8List.fromList(bytes);
     return Body._(
@@ -44,6 +61,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable text body.
   static Body fromText(
     String value, {
     Encoding encoding = utf8,
@@ -59,6 +77,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable JSON body.
   static Body fromJson(
     Object? value, {
     String contentType = 'application/json; charset=utf-8',
@@ -73,6 +92,7 @@ final class Body {
     );
   }
 
+  /// Creates a one-shot streaming body.
   static Body stream(Stream<List<int>> stream, {int? contentLength}) {
     var consumed = false;
     return Body._(
@@ -89,6 +109,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable streaming body from an [open] factory.
   static Body replayableStream(
     BodyStreamFactory open, {
     int? contentLength,
@@ -104,6 +125,9 @@ final class Body {
     );
   }
 
+  /// Converts common request body inputs to a [Body].
+  ///
+  /// Returns `null` for `null`. Throws [ArgumentError] for unsupported inputs.
   static Body? from(Object? value) {
     return switch (value) {
       null => null,
@@ -120,6 +144,7 @@ final class Body {
     };
   }
 
+  /// Creates a replayable multipart form body.
   static Body fromFormData(ht.FormData formData) {
     final encoded = formData.encodeMultipart(boundary: _multipartBoundary());
     return Body._(
@@ -131,6 +156,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable `application/x-www-form-urlencoded` body.
   static Body fromUrlSearchParams(ht.URLSearchParams params) {
     final data = utf8.encode(params.toString());
     return Body._(
@@ -142,6 +168,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable body from a [ht.Blob].
   static Body fromBlob(ht.Blob blob) {
     return Body._(
       kind: BodyKind.file,
@@ -152,6 +179,7 @@ final class Body {
     );
   }
 
+  /// Creates a replayable body from an `ht` body clone factory.
   static Body fromHtBody(ht.Body body) {
     return Body._(
       kind: BodyKind.stream,
@@ -167,6 +195,10 @@ final class Body {
     return '----oxy-$timestamp-$counter-$random';
   }
 
+  /// Opens the body stream.
+  ///
+  /// Throws [BodyStateError] if this body is not replayable and was already
+  /// opened.
   Stream<Uint8List> open() {
     if (!replayable) {
       if (_used) {
@@ -180,6 +212,9 @@ final class Body {
     });
   }
 
+  /// Reads the body as bytes.
+  ///
+  /// Throws [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
   Future<Uint8List> bytes({int? maxBytes}) async {
     final builder = BytesBuilder(copy: false);
     await for (final chunk in open()) {
@@ -191,15 +226,22 @@ final class Body {
     return builder.takeBytes();
   }
 
+  /// Reads the body as text using [encoding].
   Future<String> text({Encoding encoding = utf8, int? maxBytes}) async {
     return encoding.decode(await bytes(maxBytes: maxBytes));
   }
 
+  /// Reads and decodes the body as JSON.
   Future<Object?> json({int? maxBytes}) async {
     return jsonDecode(await text(maxBytes: maxBytes));
   }
 }
 
+/// A response body with replayability and content length metadata.
+///
+/// Response bodies from bytes and text are replayable. Response bodies from a
+/// raw stream are one-shot unless middleware buffers them into a new
+/// [ResponseBody].
 final class ResponseBody {
   ResponseBody._({
     required bool replayable,
@@ -209,16 +251,21 @@ final class ResponseBody {
        _open = open;
 
   final bool _replayable;
+
+  /// The known content length, or `null` when unknown.
   final int? contentLength;
   final BodyStreamFactory _open;
   bool _used = false;
 
+  /// Whether [open] can be called more than once.
   bool get replayable => _replayable;
 
+  /// Creates an empty replayable response body.
   static ResponseBody empty() {
     return ResponseBody.fromBytes(const <int>[]);
   }
 
+  /// Creates a replayable response body from [bytes].
   static ResponseBody fromBytes(List<int> bytes) {
     final data = Uint8List.fromList(bytes);
     return ResponseBody._(
@@ -228,10 +275,12 @@ final class ResponseBody {
     );
   }
 
+  /// Creates a replayable text response body.
   static ResponseBody fromText(String value, {Encoding encoding = utf8}) {
     return ResponseBody.fromBytes(encoding.encode(value));
   }
 
+  /// Creates a one-shot streaming response body.
   static ResponseBody stream(Stream<List<int>> stream, {int? contentLength}) {
     var consumed = false;
     return ResponseBody._(
@@ -247,6 +296,10 @@ final class ResponseBody {
     );
   }
 
+  /// Opens the response body stream.
+  ///
+  /// Throws [BodyStateError] if this body is not replayable and was already
+  /// opened.
   Stream<Uint8List> open() {
     if (!_replayable) {
       if (_used) {
@@ -260,6 +313,9 @@ final class ResponseBody {
     });
   }
 
+  /// Reads the response body as bytes.
+  ///
+  /// Throws [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
   Future<Uint8List> bytes({int? maxBytes}) async {
     final builder = BytesBuilder(copy: false);
     await for (final chunk in open()) {
@@ -271,10 +327,12 @@ final class ResponseBody {
     return builder.takeBytes();
   }
 
+  /// Reads the response body as text using [encoding].
   Future<String> text({Encoding encoding = utf8, int? maxBytes}) async {
     return encoding.decode(await bytes(maxBytes: maxBytes));
   }
 
+  /// Reads and decodes the response body as JSON.
   Future<Object?> json({int? maxBytes}) async {
     return jsonDecode(await text(maxBytes: maxBytes));
   }

--- a/lib/src/core/errors.dart
+++ b/lib/src/core/errors.dart
@@ -1,8 +1,13 @@
 import 'request.dart';
 import 'response.dart';
 
+/// The request phase that exceeded a configured timeout.
 enum TimeoutPhase { connect, send, firstByte, read, total }
 
+/// Base type for errors produced by Oxy request processing.
+///
+/// Subtypes carry the request, response, original cause, stack trace, and
+/// retry metadata when that context is available.
 sealed class RequestError implements Exception {
   const RequestError(
     this.message, {
@@ -14,18 +19,32 @@ sealed class RequestError implements Exception {
     this.retryable = false,
   });
 
+  /// Human-readable error message.
   final String message;
+
+  /// The request associated with this error, when available.
   final Request? request;
+
+  /// The response associated with this error, when available.
   final Response? response;
+
+  /// The original error that caused this failure, when available.
   final Object? cause;
+
+  /// The original stack trace, when available.
   final StackTrace? trace;
+
+  /// Whether the request was sent before the error occurred.
   final bool sent;
+
+  /// Whether this error is retryable by policy.
   final bool retryable;
 
   @override
   String toString() => '$runtimeType: $message';
 }
 
+/// A transport or network failure.
 final class NetworkError extends RequestError {
   const NetworkError(
     super.message, {
@@ -37,6 +56,7 @@ final class NetworkError extends RequestError {
   });
 }
 
+/// A request timeout.
 final class TimeoutError extends RequestError {
   const TimeoutError({
     required this.phase,
@@ -48,17 +68,23 @@ final class TimeoutError extends RequestError {
     super.retryable = true,
   }) : super('Timeout during $phase after $duration');
 
+  /// The request phase that timed out.
   final TimeoutPhase phase;
+
+  /// The configured timeout duration.
   final Duration duration;
 }
 
+/// A request cancellation.
 final class CancelError extends RequestError {
   CancelError({this.reason, super.request, super.trace, super.sent})
     : super('Request cancelled', cause: reason, retryable: false);
 
+  /// The cancellation reason supplied by the caller.
   final Object? reason;
 }
 
+/// A response rejected by status or redirect policy.
 final class StatusError extends RequestError {
   StatusError(
     this.statusResponse, {
@@ -74,18 +100,24 @@ final class StatusError extends RequestError {
          retryable: false,
        );
 
+  /// The rejected response.
   final Response statusResponse;
+
+  /// A bounded UTF-8 body preview, when available.
   final String? bodyPreview;
 }
 
+/// A response decoding or mapping failure.
 final class DecodeError extends RequestError {
   const DecodeError(super.message, {super.response, super.cause, super.trace});
 }
 
+/// A configuration or policy failure before a request is sent.
 final class PolicyError extends RequestError {
   const PolicyError(super.message, {super.request, super.cause, super.trace});
 }
 
+/// A retry loop that exhausted all attempts.
 final class RetryError extends RequestError {
   const RetryError({
     required this.attempts,
@@ -101,11 +133,17 @@ final class RetryError extends RequestError {
          retryable: false,
        );
 
+  /// Total number of attempts, including the first attempt.
   final int attempts;
+
+  /// The last retryable error, when the final failure was an error.
   final Object? lastError;
+
+  /// The last retryable response, when the final failure was a response.
   final Response? lastResponse;
 }
 
+/// A middleware failure with middleware context.
 final class MiddlewareError extends RequestError {
   const MiddlewareError({
     required this.middleware,
@@ -115,16 +153,20 @@ final class MiddlewareError extends RequestError {
     super.trace,
   }) : super(message);
 
+  /// The middleware label associated with the failure.
   final String middleware;
 }
 
+/// A body stream was used in an invalid state.
 final class BodyStateError extends RequestError {
   const BodyStateError(super.message, {super.request, super.cause});
 }
 
+/// A body exceeded a configured byte limit while being read.
 final class BodyTooLargeError extends RequestError {
   const BodyTooLargeError({required this.limit, super.request, super.response})
     : super('Body exceeded configured limit of $limit bytes.');
 
+  /// The configured byte limit.
   final int limit;
 }

--- a/lib/src/core/headers.dart
+++ b/lib/src/core/headers.dart
@@ -1,5 +1,10 @@
+/// Inputs accepted by [Headers].
 typedef HeadersInit = Object?;
 
+/// Case-insensitive HTTP headers with multi-value support.
+///
+/// Header names are normalized to lowercase. `set-cookie` is kept as separate
+/// values through [getAll] and [getSetCookie].
 final class Headers with Iterable<MapEntry<String, String>> {
   Headers([HeadersInit init]) {
     _fill(init);
@@ -23,24 +28,32 @@ final class Headers with Iterable<MapEntry<String, String>> {
   @override
   bool get isNotEmpty => _values.isNotEmpty;
 
+  /// Appends [value] to [name].
   void append(String name, Object value) {
     final key = _normalizeName(name);
     final text = value.toString();
     _values.putIfAbsent(key, () => <String>[]).add(text);
   }
 
+  /// Replaces all values for [name] with [value].
   void set(String name, Object value) {
     _values[_normalizeName(name)] = <String>[value.toString()];
   }
 
+  /// Removes all values for [name].
   void delete(String name) {
     _values.remove(_normalizeName(name));
   }
 
+  /// Whether [name] is present.
   bool has(String name) {
     return _values.containsKey(_normalizeName(name));
   }
 
+  /// The comma-joined value for [name], or `null`.
+  ///
+  /// For `set-cookie`, values are joined with newlines to avoid comma parsing
+  /// ambiguity. Prefer [getSetCookie] for cookie handling.
   String? get(String name) {
     final values = _values[_normalizeName(name)];
     if (values == null || values.isEmpty) {
@@ -50,16 +63,21 @@ final class Headers with Iterable<MapEntry<String, String>> {
     return values.join(_normalizeName(name) == 'set-cookie' ? '\n' : ',');
   }
 
+  /// All values for [name].
   List<String> getAll(String name) {
     return List<String>.unmodifiable(_values[_normalizeName(name)] ?? const []);
   }
 
+  /// All `set-cookie` header values.
   List<String> getSetCookie() => getAll('set-cookie');
 
+  /// The normalized header names.
   Iterable<String> keys() => _values.keys;
 
+  /// A mutable copy of these headers.
   Headers copy() => Headers(this);
 
+  /// An unmodifiable multi-value map.
   Map<String, List<String>> toMultiValueMap() {
     return Map<String, List<String>>.unmodifiable(
       _values.map((key, value) {

--- a/lib/src/core/request.dart
+++ b/lib/src/core/request.dart
@@ -3,6 +3,19 @@ import 'body.dart';
 import 'headers.dart';
 import '../options.dart';
 
+/// An immutable HTTP request prepared for Oxy's pipeline.
+///
+/// A request stores the method, URI, headers, optional [Body], and
+/// per-request [RequestOptions]. Use [copyWith] or [withHeader] to derive a
+/// modified request in middleware.
+///
+/// ```dart
+/// final request = Request(
+///   '/users',
+///   method: 'POST',
+///   body: Body.fromJson({'name': 'oxy'}),
+/// );
+/// ```
 final class Request {
   Request(
     Object url, {
@@ -29,15 +42,28 @@ final class Request {
     required this.attributes,
   });
 
+  /// The HTTP method.
   final String method;
+
+  /// The request URI before client base URL resolution.
   final Uri uri;
+
+  /// The request headers.
   final Headers headers;
+
+  /// The optional request body.
   final Body? body;
+
+  /// Per-request options.
   final RequestOptions options;
+
+  /// Request attributes used by middleware and transports.
   final Attributes attributes;
 
+  /// The string form of [uri].
   String get url => uri.toString();
 
+  /// Creates a copy with selected values replaced.
   Request copyWith({
     String? method,
     Uri? uri,
@@ -57,6 +83,7 @@ final class Request {
     );
   }
 
+  /// Creates a copy with one header set to [value].
   Request withHeader(String name, Object value) {
     final nextHeaders = headers.copy()..set(name, value);
     return copyWith(headers: nextHeaders);

--- a/lib/src/core/response.dart
+++ b/lib/src/core/response.dart
@@ -5,6 +5,14 @@ import 'errors.dart';
 import 'headers.dart';
 import '../options.dart';
 
+/// An HTTP response returned by Oxy.
+///
+/// A response owns status metadata, headers, and an optional [ResponseBody].
+/// Response instances are immutable; use [copyWith] or [buffered] when a
+/// middleware needs to derive a modified response.
+///
+/// Response bodies can be replayable or one-shot. Convenience readers such as
+/// [text], [json], and [bytes] consume the body stream.
 final class Response {
   Response(
     Object? body, {
@@ -18,6 +26,7 @@ final class Response {
        headers = Headers(headers),
        url = url ?? Uri();
 
+  /// Creates a replayable response from raw [bytes].
   Response.bytes(
     List<int> bytes, {
     this.status = 200,
@@ -30,6 +39,7 @@ final class Response {
        headers = Headers(headers),
        url = url ?? Uri();
 
+  /// Creates a replayable UTF-8 text response.
   Response.text(
     String text, {
     this.status = 200,
@@ -46,6 +56,7 @@ final class Response {
        ),
        url = url ?? Uri();
 
+  /// Creates a replayable JSON response.
   Response.json(
     Object? value, {
     this.status = 200,
@@ -62,6 +73,7 @@ final class Response {
        ),
        url = url ?? Uri();
 
+  /// Creates a one-shot streaming response.
   Response.stream(
     Stream<List<int>> stream, {
     this.status = 200,
@@ -75,28 +87,52 @@ final class Response {
        headers = Headers(headers),
        url = url ?? Uri();
 
+  /// The HTTP status code.
   final int status;
+
+  /// The HTTP status reason phrase.
   final String statusText;
+
+  /// The response headers.
   final Headers headers;
+
+  /// The final response URL, when known.
   final Uri url;
+
+  /// Whether the response followed at least one redirect.
   final bool redirected;
+
+  /// Whether the response was served by `CacheMiddleware`.
   final bool fromCache;
+
+  /// The optional response body.
   final ResponseBody? body;
 
+  /// Whether [status] is in the 2xx range.
   bool get ok => status >= 200 && status <= 299;
 
+  /// Opens the response body stream.
+  ///
+  /// Returns an empty stream when [body] is `null`.
   Stream<List<int>> stream() {
     return body?.open() ?? const Stream<List<int>>.empty();
   }
 
+  /// Reads the response body as bytes.
+  ///
+  /// Throws [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
   Future<List<int>> bytes({int? maxBytes}) async {
     return body?.bytes(maxBytes: maxBytes) ?? const <int>[];
   }
 
+  /// Reads the response body as text using [encoding].
   Future<String> text({Encoding encoding = utf8, int? maxBytes}) async {
     return body?.text(encoding: encoding, maxBytes: maxBytes) ?? '';
   }
 
+  /// Reads and decodes the response body as JSON.
+  ///
+  /// Throws [DecodeError] when decoding fails.
   Future<T> json<T>({int? maxBytes}) async {
     try {
       return await body?.json(maxBytes: maxBytes) as T;
@@ -110,6 +146,10 @@ final class Response {
     }
   }
 
+  /// Reads JSON and maps it to [T].
+  ///
+  /// If [decoder] is omitted, the decoded payload is cast to [T].
+  /// Throws [DecodeError] when JSON decoding or mapping fails.
   Future<T> decode<T>({Decoder<T>? decoder, int? maxBytes}) async {
     Object? payload;
     try {
@@ -138,6 +178,10 @@ final class Response {
     }
   }
 
+  /// Reads and discards the response body.
+  ///
+  /// This is useful before retrying or closing a response. Throws
+  /// [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
   Future<void> drain({int? maxBytes = 64 * 1024}) async {
     var transferred = 0;
     await for (final chunk in stream()) {
@@ -148,6 +192,9 @@ final class Response {
     }
   }
 
+  /// Returns a replayable response by buffering the body into memory.
+  ///
+  /// Throws [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
   Future<Response> buffered({int? maxBytes = 1024 * 1024}) async {
     final data = await bytes(maxBytes: maxBytes);
     return Response.bytes(
@@ -161,6 +208,9 @@ final class Response {
     );
   }
 
+  /// Creates a copy with selected values replaced.
+  ///
+  /// Use [clearBody] to create a response without a body.
   Response copyWith({
     Object? body,
     bool clearBody = false,

--- a/lib/src/core/result.dart
+++ b/lib/src/core/result.dart
@@ -1,6 +1,12 @@
+/// A no-throw result for request helpers.
+///
+/// Use [Result.capture], `Client.sendResult`, `Client.requestResult`, or
+/// `fetchResult` when an HTTP failure should be handled as a value instead of
+/// an exception.
 sealed class Result<T> {
   const Result();
 
+  /// Runs [action] and captures either a [Success] or [Failure].
   static Future<Result<T>> capture<T>(Future<T> Function() action) async {
     try {
       return Success<T>(await action());
@@ -9,12 +15,22 @@ sealed class Result<T> {
     }
   }
 
+  /// Whether this result contains a value.
   bool get isSuccess;
+
+  /// Whether this result contains an error.
   bool get isFailure => !isSuccess;
+
+  /// The value for [Success], otherwise `null`.
   T? get value;
+
+  /// The error for [Failure], otherwise `null`.
   Object? get error;
+
+  /// The stack trace for [Failure], otherwise `null`.
   StackTrace? get trace;
 
+  /// Folds this result into one value.
   R fold<R>({
     required R Function(T value) onSuccess,
     required R Function(Object error, StackTrace trace) onFailure,
@@ -25,6 +41,7 @@ sealed class Result<T> {
     };
   }
 
+  /// Maps a successful value while preserving failures.
   Result<R> map<R>(R Function(T value) transform) {
     return switch (this) {
       Success<T>(:final data) => _mapSuccess(data, transform),
@@ -32,6 +49,7 @@ sealed class Result<T> {
     };
   }
 
+  /// Returns the value or rethrows the captured error with its stack trace.
   T getOrThrow() {
     return switch (this) {
       Success<T>(:final data) => data,
@@ -51,9 +69,11 @@ sealed class Result<T> {
   }
 }
 
+/// A successful [Result].
 final class Success<T> extends Result<T> {
   const Success(this.data);
 
+  /// The captured value.
   final T data;
 
   @override
@@ -69,10 +89,14 @@ final class Success<T> extends Result<T> {
   StackTrace? get trace => null;
 }
 
+/// A failed [Result].
 final class Failure<T> extends Result<T> {
   const Failure(this.cause, this.stack);
 
+  /// The captured error.
   final Object cause;
+
+  /// The captured stack trace.
   final StackTrace stack;
 
   @override

--- a/lib/src/features/auth.dart
+++ b/lib/src/features/auth.dart
@@ -5,9 +5,11 @@ import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 
+/// Resolves an authentication token for a request.
 typedef AuthTokenProvider =
     FutureOr<String?> Function(Request request, Context context);
 
+/// Adds an authorization header when a token is available.
 final class AuthMiddleware implements Middleware {
   AuthMiddleware({
     required this.tokenProvider,
@@ -16,6 +18,7 @@ final class AuthMiddleware implements Middleware {
     this.overrideExisting = false,
   });
 
+  /// Creates middleware that always uses [token].
   AuthMiddleware.staticToken(
     String token, {
     String? scheme = 'Bearer',
@@ -28,9 +31,16 @@ final class AuthMiddleware implements Middleware {
          overrideExisting: overrideExisting,
        );
 
+  /// Provider used to resolve the token.
   final AuthTokenProvider tokenProvider;
+
+  /// Authentication scheme prepended to the token, or `null` for raw tokens.
   final String? scheme;
+
+  /// Header name to write.
   final String headerName;
+
+  /// Whether an existing header should be replaced.
   final bool overrideExisting;
 
   @override

--- a/lib/src/features/cache.dart
+++ b/lib/src/features/cache.dart
@@ -10,8 +10,10 @@ import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 import '../policies.dart';
 
+/// Builds a cache key for a request.
 typedef CacheKeyBuilder = String Function(Request request, Context context);
 
+/// A response stored by [CacheStore].
 final class CachedResponse {
   const CachedResponse({
     required this.response,
@@ -20,11 +22,19 @@ final class CachedResponse {
     required this.etag,
   });
 
+  /// The buffered response.
   final Response response;
+
+  /// When the response was stored.
   final DateTime storedAt;
+
+  /// When the response expires, or `null` if it requires validation.
   final DateTime? expiresAt;
+
+  /// The response ETag used for revalidation.
   final String? etag;
 
+  /// Whether this response is still fresh at [nowUtc].
   bool isFresh(DateTime nowUtc) {
     return expiresAt != null && nowUtc.isBefore(expiresAt!);
   }
@@ -41,19 +51,30 @@ final class CachedResponse {
   }
 }
 
+/// Storage used by [CacheMiddleware].
 abstract interface class CacheStore {
+  /// Reads the cached response for [key].
   Future<CachedResponse?> read(String key);
+
+  /// Stores [value] for [key].
   Future<void> write(String key, CachedResponse value);
+
+  /// Removes [key].
   Future<void> delete(String key);
+
+  /// Removes all cached entries.
   Future<void> clear();
 }
 
+/// In-memory least-recently-used cache store.
 final class MemoryCacheStore implements CacheStore {
   MemoryCacheStore({this.maxEntries = defaultMaxEntries})
     : assert(maxEntries == null || maxEntries > 0, 'maxEntries must be > 0');
 
+  /// Default maximum number of entries.
   static const int defaultMaxEntries = 128;
 
+  /// Maximum number of entries, or `null` for no entry limit.
   final int? maxEntries;
   final Map<String, CachedResponse> _entries = <String, CachedResponse>{};
 
@@ -95,6 +116,10 @@ final class MemoryCacheStore implements CacheStore {
   }
 }
 
+/// HTTP cache middleware for cacheable `GET` and `HEAD` responses.
+///
+/// The middleware stores bounded, replayable responses and revalidates cached
+/// entries with ETag or Last-Modified validators when needed.
 final class CacheMiddleware implements Middleware {
   CacheMiddleware({
     CacheStore? store,
@@ -105,7 +130,11 @@ final class CacheMiddleware implements Middleware {
        _methods = methods.map((method) => method.toUpperCase()).toSet();
 
   final CacheStore _store;
+
+  /// Cache key builder.
   final CacheKeyBuilder keyBuilder;
+
+  /// Maximum response body size stored in memory.
   final int maxEntryBytes;
   final Set<String> _methods;
 

--- a/lib/src/features/cookie.dart
+++ b/lib/src/features/cookie.dart
@@ -10,6 +10,9 @@ export 'package:ocookie/ocookie.dart'
         CookiePriority,
         CookieSameSite;
 
+/// Parses a `Set-Cookie` header for [requestUri].
+///
+/// The returned cookie is normalized for host-only/domain/path matching.
 ocookie.Cookie parseSetCookie(String setCookie, Uri requestUri) {
   return _normalizeCookie(
     ocookie.Cookie.fromString(setCookie),
@@ -17,7 +20,9 @@ ocookie.Cookie parseSetCookie(String setCookie, Uri requestUri) {
   ).cookie;
 }
 
+/// Request matching helpers for [ocookie.Cookie].
 extension CookieRequestExtension on ocookie.Cookie {
+  /// Whether this cookie is expired at [nowUtc].
   bool isExpired(DateTime nowUtc) {
     final now = nowUtc.toUtc();
     if (maxAge != null && maxAge == Duration.zero) {
@@ -29,6 +34,7 @@ extension CookieRequestExtension on ocookie.Cookie {
     return false;
   }
 
+  /// Whether this cookie should be sent to [uri].
   bool matchesUri(Uri uri) {
     final host = uri.host.toLowerCase();
     final domain = _cookieDomain(this);
@@ -54,15 +60,23 @@ extension CookieRequestExtension on ocookie.Cookie {
     return true;
   }
 
+  /// Serializes this cookie for a `Cookie` request header.
   String toRequestCookie() => ocookie.Cookie(name, value).serialize();
 }
 
+/// Cookie storage used by `CookieMiddleware`.
 abstract interface class CookieJar {
+  /// Loads cookies that may be sent to [uri].
   Future<List<ocookie.Cookie>> load(Uri uri);
+
+  /// Saves cookies received from [uri].
   Future<void> save(Uri uri, List<ocookie.Cookie> cookies);
+
+  /// Removes all cookies.
   Future<void> clear();
 }
 
+/// In-memory [CookieJar] implementation.
 final class MemoryCookieJar implements CookieJar {
   final List<_StoredCookie> _cookies = <_StoredCookie>[];
 

--- a/lib/src/features/cookie_middleware.dart
+++ b/lib/src/features/cookie_middleware.dart
@@ -6,9 +6,14 @@ import '../pipeline/internal_attributes.dart';
 import '../pipeline/middleware.dart';
 import 'cookie.dart';
 
+/// Adds cookie jar support for native and test transports.
+///
+/// Browser requests already use the browser's cookie handling, so this
+/// middleware is a no-op on Web transports.
 final class CookieMiddleware implements Middleware {
   const CookieMiddleware(this.jar);
 
+  /// Cookie storage used by the middleware.
   final CookieJar jar;
 
   @override

--- a/lib/src/features/logging.dart
+++ b/lib/src/features/logging.dart
@@ -4,8 +4,12 @@ import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 
+/// Receives formatted log messages.
 typedef LogPrinter = void Function(String message);
 
+/// Logs request start, response completion, and failures.
+///
+/// User info, query strings, and fragments are redacted before logging.
 final class LoggingMiddleware implements Middleware {
   LoggingMiddleware({LogPrinter? printer}) : _printer = printer ?? print;
 

--- a/lib/src/features/request_id.dart
+++ b/lib/src/features/request_id.dart
@@ -6,9 +6,11 @@ import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 
+/// Produces a request ID for a request.
 typedef RequestIdProvider =
     FutureOr<String?> Function(Request request, Context context);
 
+/// Adds a request ID header when one is available.
 final class RequestIdMiddleware implements Middleware {
   RequestIdMiddleware({
     RequestIdProvider? requestIdProvider,
@@ -17,7 +19,11 @@ final class RequestIdMiddleware implements Middleware {
   }) : _requestIdProvider = requestIdProvider ?? _defaultRequestId;
 
   final RequestIdProvider _requestIdProvider;
+
+  /// Header name to write.
   final String headerName;
+
+  /// Whether an existing request ID header should be replaced.
   final bool overrideExisting;
 
   static final Random _random = Random();

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -6,17 +6,31 @@ import 'pipeline/middleware.dart';
 import 'policies.dart';
 import 'transport/transport.dart';
 
+/// A JSON object represented by string keys and nullable JSON-like values.
 typedef JsonMap = Map<String, Object?>;
+
+/// Query parameters passed to request helpers.
+///
+/// Values are converted to strings by Oxy when the final URL is prepared.
 typedef QueryMap = Map<String, Object?>;
+
+/// Maps a decoded JSON payload to a typed value.
 typedef Decoder<T> = T Function(Object? value);
+
+/// Receives upload or download progress for a request.
 typedef ProgressCallback = void Function(TransferProgress progress);
 
+/// Progress reported while bytes are transferred.
 final class TransferProgress {
   const TransferProgress({required this.transferred, required this.total});
 
+  /// The number of bytes transferred so far.
   final int transferred;
+
+  /// The total number of bytes, or `null` when the transport cannot know it.
   final int? total;
 
+  /// The completed fraction, or `null` when [total] is not available.
   double? get percent {
     final total = this.total;
     if (total == null || total == 0) {
@@ -26,6 +40,10 @@ final class TransferProgress {
   }
 }
 
+/// Defaults used by a `Client`.
+///
+/// These options are resolved once per request and can be overridden for a
+/// single send with [RequestOptions].
 final class ClientOptions {
   const ClientOptions({
     this.baseUrl,
@@ -45,22 +63,52 @@ final class ClientOptions {
     this.onEvent,
   });
 
+  /// The base URL used to resolve relative request URLs.
   final Uri? baseUrl;
+
+  /// Headers added to every request unless overridden by the request.
   final HeadersInit? defaultHeaders;
+
+  /// Timeout policy applied to every request by default.
   final TimeoutPolicy timeoutPolicy;
+
+  /// Retry policy applied to retryable requests by default.
   final RetryPolicy retryPolicy;
+
+  /// Redirect policy applied to every request by default.
   final RedirectPolicy redirectPolicy;
+
+  /// Status validation policy applied to every response by default.
   final StatusPolicy statusPolicy;
+
+  /// Middleware that runs once for each logical request.
   final List<Middleware> middleware;
+
+  /// Middleware that runs for each network attempt.
   final List<Middleware> networkMiddleware;
+
+  /// Lifecycle hooks applied to every request.
   final Hooks hooks;
+
+  /// Custom transport used by the client, or `null` to use the platform default.
   final Transport? transport;
+
+  /// Whether the native default transport should keep connections alive.
   final bool keepAlive;
+
+  /// User agent sent by non-Web default transports.
   final String userAgent;
+
+  /// Maximum number of response body bytes to include in `StatusError` previews.
   final int errorBodyPreviewLimit;
+
+  /// Client-level attributes visible to middleware and transports.
   final Attributes attributes;
+
+  /// Event sink for observing request lifecycle events.
   final EventSink? onEvent;
 
+  /// Creates a copy with selected values replaced.
   ClientOptions copyWith({
     Uri? baseUrl,
     HeadersInit? defaultHeaders,
@@ -99,6 +147,9 @@ final class ClientOptions {
   }
 }
 
+/// Per-request overrides.
+///
+/// Values set here take precedence over [ClientOptions] for a single request.
 final class RequestOptions {
   const RequestOptions({
     this.headers,
@@ -116,20 +167,46 @@ final class RequestOptions {
     this.attributes = const Attributes(),
   });
 
+  /// Headers merged into the prepared request.
   final HeadersInit? headers;
+
+  /// Query parameters merged into the prepared URL.
   final QueryMap? query;
+
+  /// Timeout policy override.
   final TimeoutPolicy? timeoutPolicy;
+
+  /// Retry policy override.
   final RetryPolicy? retryPolicy;
+
+  /// Redirect policy override.
   final RedirectPolicy? redirectPolicy;
+
+  /// Status validation policy override.
   final StatusPolicy? statusPolicy;
+
+  /// Application middleware added to this request.
   final List<Middleware> middleware;
+
+  /// Network middleware added to this request.
   final List<Middleware> networkMiddleware;
+
+  /// Lifecycle hook overrides.
   final Hooks? hooks;
+
+  /// Cancellation signal for this request.
   final AbortSignal? signal;
+
+  /// Upload progress callback.
   final ProgressCallback? onSendProgress;
+
+  /// Download progress callback.
   final ProgressCallback? onReceiveProgress;
+
+  /// Request-level attributes visible to middleware and transports.
   final Attributes attributes;
 
+  /// Creates a copy with selected values replaced.
   RequestOptions copyWith({
     HeadersInit? headers,
     QueryMap? query,

--- a/lib/src/pipeline/context.dart
+++ b/lib/src/pipeline/context.dart
@@ -6,6 +6,10 @@ import '../policies.dart';
 import '../transport/capability.dart';
 import 'events.dart';
 
+/// Per-request execution context passed through middleware and transports.
+///
+/// The context contains the resolved policies, platform capability, current
+/// retry attempt, attributes, cancellation signal, and event sink.
 final class Context {
   const Context({
     required this.clientOptions,
@@ -22,24 +26,52 @@ final class Context {
     this.onEvent,
   });
 
+  /// Client-level defaults.
   final ClientOptions clientOptions;
+
+  /// Request-level overrides.
   final RequestOptions requestOptions;
+
+  /// Resolved timeout policy.
   final TimeoutPolicy timeoutPolicy;
+
+  /// Resolved retry policy.
   final RetryPolicy retryPolicy;
+
+  /// Resolved redirect policy.
   final RedirectPolicy redirectPolicy;
+
+  /// Resolved status policy.
   final StatusPolicy statusPolicy;
+
+  /// Capabilities of the active transport.
   final PlatformCapability capability;
+
+  /// Merged client, request, and send attributes.
   final Attributes attributes;
+
+  /// When the logical request started.
   final DateTime createdAt;
+
+  /// Zero-based network attempt.
   final int attempt;
+
+  /// Cancellation signal for this attempt.
   final AbortSignal? signal;
+
+  /// Event sink for request lifecycle events.
   final EventSink? onEvent;
 
+  /// Upload progress callback for this request.
   ProgressCallback? get onSendProgress => requestOptions.onSendProgress;
+
+  /// Download progress callback for this request.
   ProgressCallback? get onReceiveProgress => requestOptions.onReceiveProgress;
 
+  /// The attribute value for [key].
   T? attribute<T extends Object>(AttributeKey<T> key) => attributes.get(key);
 
+  /// Creates a copy with selected execution values replaced.
   Context copyWith({
     RequestOptions? requestOptions,
     TimeoutPolicy? timeoutPolicy,
@@ -70,6 +102,7 @@ final class Context {
     );
   }
 
+  /// Emits a request lifecycle event through [onEvent].
   void emit(
     RequestEventType type,
     Request request, {

--- a/lib/src/pipeline/events.dart
+++ b/lib/src/pipeline/events.dart
@@ -1,21 +1,43 @@
 import '../core/request.dart';
 import '../core/response.dart';
 
+/// Receives request lifecycle events.
 typedef EventSink = void Function(RequestEvent event);
 
+/// Event types emitted while a request moves through the client.
 enum RequestEventType {
+  /// The logical request started.
   start,
+
+  /// The request was resolved against client and request options.
   prepared,
+
+  /// A middleware started.
   middlewareStart,
+
+  /// A middleware completed.
   middlewareEnd,
+
+  /// A network attempt started.
   attemptStart,
+
+  /// A network attempt completed with a response.
   attemptEnd,
+
+  /// A retry was scheduled.
   retryScheduled,
+
+  /// A retry was skipped.
   retrySkipped,
+
+  /// A response failed status validation.
   statusFailed,
+
+  /// The logical request completed successfully.
   complete,
 }
 
+/// A request lifecycle event.
 final class RequestEvent {
   const RequestEvent({
     required this.type,
@@ -27,15 +49,29 @@ final class RequestEvent {
     this.detail,
   });
 
+  /// The event type.
   final RequestEventType type;
+
+  /// The request associated with the event.
   final Request request;
+
+  /// The zero-based attempt associated with the event.
   final int attempt;
+
+  /// When the event was emitted.
   final DateTime timestamp;
+
+  /// The response associated with the event, when available.
   final Response? response;
+
+  /// The error associated with the event, when available.
   final Object? error;
+
+  /// Additional event detail, when available.
   final String? detail;
 }
 
+/// Emits a [RequestEvent] to [sink] when [sink] is not `null`.
 void emitEvent(
   EventSink? sink,
   RequestEventType type, {

--- a/lib/src/pipeline/middleware.dart
+++ b/lib/src/pipeline/middleware.dart
@@ -4,22 +4,35 @@ import '../core/request.dart';
 import '../core/response.dart';
 import 'context.dart';
 
+/// Continues request processing from middleware.
 typedef Next = Future<Response> Function(Request request, Context context);
 
+/// Intercepts a request before or around the next pipeline step.
+///
+/// Application middleware runs once per logical request. Network middleware
+/// runs once per network attempt, including retries and redirects.
 abstract interface class Middleware {
+  /// Handles [request] and either returns a [Response] or calls [next].
   Future<Response> intercept(Request request, Context context, Next next);
 }
 
+/// Hook called with a request and context.
 typedef HookCallback =
     FutureOr<void> Function(Request request, Context context);
+
+/// Hook called with a response that may be replaced.
 typedef ResponseHookCallback =
     FutureOr<Response> Function(
       Request request,
       Response response,
       Context context,
     );
+
+/// Hook called when request processing fails.
 typedef ErrorHookCallback =
     FutureOr<void> Function(Request request, Object error, Context context);
+
+/// Hook called before a retry delay.
 typedef RetryHookCallback =
     FutureOr<void> Function(
       Request request,
@@ -29,6 +42,7 @@ typedef RetryHookCallback =
       Context context,
     );
 
+/// Optional lifecycle callbacks for request processing.
 final class Hooks {
   const Hooks({
     this.onRequest,
@@ -38,12 +52,22 @@ final class Hooks {
     this.onFinally,
   });
 
+  /// Called before application middleware.
   final HookCallback? onRequest;
+
+  /// Called after response policies and before the final response is returned.
   final ResponseHookCallback? onResponse;
+
+  /// Called when request processing fails.
   final ErrorHookCallback? onError;
+
+  /// Called before a retry delay.
   final RetryHookCallback? onRetry;
+
+  /// Called once request processing has finished.
   final HookCallback? onFinally;
 
+  /// Merges [other] over this hook set.
   Hooks merge(Hooks? other) {
     if (other == null) {
       return this;

--- a/lib/src/policies.dart
+++ b/lib/src/policies.dart
@@ -3,6 +3,11 @@ import 'dart:math';
 import 'core/request.dart';
 import 'core/response.dart';
 
+/// Timeouts applied to phases of a request.
+///
+/// A `null` phase timeout disables that phase. [total] bounds the whole
+/// logical request, including retries, redirects, middleware, and response body
+/// reads performed through the returned [Response].
 final class TimeoutPolicy {
   const TimeoutPolicy({
     this.connect = const Duration(seconds: 10),
@@ -12,22 +17,39 @@ final class TimeoutPolicy {
     this.total = const Duration(seconds: 30),
   });
 
+  /// Maximum time to establish a native connection.
   final Duration? connect;
+
+  /// Maximum time to send the request body.
   final Duration? send;
+
+  /// Maximum time to receive the first response byte.
   final Duration? firstByte;
+
+  /// Maximum idle time while reading response body chunks.
   final Duration? read;
+
+  /// Maximum time for the whole logical request.
   final Duration? total;
 }
 
+/// Controls which HTTP responses are considered successful.
 final class StatusPolicy {
   const StatusPolicy({this.enabled = true, this.accept});
 
+  /// Throws `StatusError` for responses outside the 2xx range.
   static const StatusPolicy throwOnError = StatusPolicy();
+
+  /// Returns every response without status validation.
   static const StatusPolicy returnResponse = StatusPolicy(enabled: false);
 
+  /// Whether status validation is enabled.
   final bool enabled;
+
+  /// Custom response acceptance predicate.
   final bool Function(Response response)? accept;
 
+  /// Whether [response] should be returned instead of throwing `StatusError`.
   bool accepts(Response response) {
     if (!enabled) {
       return true;
@@ -40,6 +62,11 @@ final class StatusPolicy {
   }
 }
 
+/// Controls retry attempts for transient failures.
+///
+/// Oxy retries conservatively by default: idempotent methods only, selected
+/// transient status codes, retryable request errors, and replayable request
+/// bodies.
 final class RetryPolicy {
   const RetryPolicy({
     this.maxRetries = 2,
@@ -52,14 +79,28 @@ final class RetryPolicy {
   }) : assert(maxRetries >= 0, 'maxRetries must be >= 0'),
        assert(jitterRatio >= 0, 'jitterRatio must be >= 0');
 
+  /// Maximum retries after the first attempt.
   final int maxRetries;
+
+  /// Whether only idempotent methods may be retried.
   final bool idempotentMethodsOnly;
+
+  /// Status codes that may be retried.
   final Set<int> retryableStatusCodes;
+
+  /// Initial delay before retrying.
   final Duration baseDelay;
+
+  /// Maximum exponential backoff delay.
   final Duration maxDelay;
+
+  /// Fraction of random jitter applied around the computed delay.
   final double jitterRatio;
+
+  /// Whether `Retry-After` response headers should override backoff.
   final bool respectRetryAfter;
 
+  /// Whether [request] is allowed to retry by method.
   bool allowsMethod(Request request) {
     if (!idempotentMethodsOnly) {
       return true;
@@ -74,10 +115,16 @@ final class RetryPolicy {
     }.contains(request.method.toUpperCase());
   }
 
+  /// Whether [response] has a retryable status code.
   bool shouldRetryResponse(Response response) {
     return retryableStatusCodes.contains(response.status);
   }
 
+  /// The delay before retrying [attempt].
+  ///
+  /// `attempt` is zero-based. When [response] has a valid `Retry-After` header
+  /// and [respectRetryAfter] is `true`, that value wins over exponential
+  /// backoff.
   Duration delayFor(int attempt, {Response? response, Random? random}) {
     assert(!baseDelay.isNegative, 'baseDelay must be >= 0');
     assert(!maxDelay.isNegative, 'maxDelay must be >= 0');
@@ -158,20 +205,39 @@ const Map<String, int> _httpMonths = <String, int>{
   'dec': 12,
 };
 
-enum RedirectMode { follow, manual, error }
+/// Redirect handling behavior.
+enum RedirectMode {
+  /// Follow redirects in Oxy when the platform transport does not own them.
+  follow,
 
+  /// Return redirect responses to the caller.
+  manual,
+
+  /// Throw `StatusError` for redirect responses.
+  error,
+}
+
+/// Controls redirect handling.
 final class RedirectPolicy {
   const RedirectPolicy({required this.mode, this.maxRedirects = 20})
     : assert(maxRedirects >= 0, 'maxRedirects must be >= 0');
 
+  /// Follows redirects up to [maxRedirects].
   static const RedirectPolicy follow = RedirectPolicy(
     mode: RedirectMode.follow,
   );
+
+  /// Returns redirect responses without following them.
   static const RedirectPolicy manual = RedirectPolicy(
     mode: RedirectMode.manual,
   );
+
+  /// Throws `StatusError` when a redirect response is encountered.
   static const RedirectPolicy error = RedirectPolicy(mode: RedirectMode.error);
 
+  /// The redirect handling mode.
   final RedirectMode mode;
+
+  /// Maximum number of redirects to follow.
   final int maxRedirects;
 }

--- a/lib/src/testing/mock_transport.dart
+++ b/lib/src/testing/mock_transport.dart
@@ -4,13 +4,20 @@ import '../pipeline/context.dart';
 import '../transport/capability.dart';
 import '../transport/transport.dart';
 
+/// Handles requests sent through [MockTransport].
 typedef MockResponder =
     Future<Response> Function(Request request, Context context);
 
+/// Deterministic in-memory transport for tests.
+///
+/// Requests are recorded in [requests], then passed to the responder supplied
+/// to the constructor.
 final class MockTransport implements Transport {
   MockTransport(this._responder);
 
   final MockResponder _responder;
+
+  /// Requests sent through this transport.
   final List<Request> requests = <Request>[];
 
   @override

--- a/lib/src/transport/capability.dart
+++ b/lib/src/transport/capability.dart
@@ -1,3 +1,7 @@
+/// Feature flags exposed by a transport implementation.
+///
+/// Middleware can use these flags to avoid relying on behavior that is not
+/// available on a platform, such as browser cookie management or proxy config.
 final class PlatformCapability {
   const PlatformCapability({
     required this.name,
@@ -9,14 +13,28 @@ final class PlatformCapability {
     required this.tlsConfiguration,
   });
 
+  /// Stable transport name such as `native`, `web`, or `test`.
   final String name;
+
+  /// Whether upload progress can be reported.
   final bool uploadProgress;
+
+  /// Whether download progress can be reported.
   final bool downloadProgress;
+
+  /// Whether request bodies may be streamed.
   final bool streamingRequestBody;
+
+  /// Whether response bodies may be streamed.
   final bool streamingResponseBody;
+
+  /// Whether proxy configuration is available.
   final bool proxyConfiguration;
+
+  /// Whether TLS configuration is available.
   final bool tlsConfiguration;
 
+  /// Capability set for the default native transport.
   static const PlatformCapability native = PlatformCapability(
     name: 'native',
     uploadProgress: true,
@@ -27,6 +45,7 @@ final class PlatformCapability {
     tlsConfiguration: true,
   );
 
+  /// Capability set for the default Web transport.
   static const PlatformCapability web = PlatformCapability(
     name: 'web',
     uploadProgress: false,
@@ -37,6 +56,7 @@ final class PlatformCapability {
     tlsConfiguration: false,
   );
 
+  /// Capability set for `MockTransport`.
   static const PlatformCapability test = PlatformCapability(
     name: 'test',
     uploadProgress: true,

--- a/lib/src/transport/transport.dart
+++ b/lib/src/transport/transport.dart
@@ -3,9 +3,14 @@ import '../core/response.dart';
 import '../pipeline/context.dart';
 import 'capability.dart';
 
+/// Low-level transport used by `Client` after policies and middleware.
 abstract interface class Transport {
+  /// Capabilities exposed by this transport.
   PlatformCapability get capability;
 
+  /// Sends a prepared [request].
   Future<Response> send(Request request, Context context);
+
+  /// Releases transport resources.
   Future<void> close();
 }

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -1,3 +1,7 @@
+/// Testing helpers for Oxy.
+///
+/// Import this library in tests that need `MockTransport` to run client code
+/// without a real server.
 library;
 
 export 'src/testing/mock_transport.dart';


### PR DESCRIPTION
## Summary
- Add Dartdoc to the public API surface users touch most: `Client`, request/response/body primitives, policies, options, errors, middleware, events, transport, and testing helpers.
- Add `doc/cookbook.md` with task-oriented workflows for reusable API clients, policies, no-throw `Result` flows, middleware composition, testing, and body replayability.
- Add checked example programs for the cookbook paths and link the cookbook from the README.
- Update `CHANGELOG.md` under `Unreleased`.

Closes #39

## Validation
- `dart analyze`
- `dart test`
- `dart doc --dry-run`
- `dart doc --validate-links --output /tmp/oxy-doc`
- `dart run example/api_client.dart`
- `dart run example/policies.dart`
- `dart run example/no_throw_result.dart`
- `dart run example/middleware_stack.dart`
- `dart pub publish --dry-run`

## Notes
- Documentation style follows Dart/Flutter API docs: short summaries first, behavior details near the relevant API, and small copyable examples.