### PR TITLE
refactor: split Client execution internals

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'core/abort.dart';
 import 'core/body.dart';
@@ -11,6 +9,7 @@ import 'core/request.dart';
 import 'core/response.dart';
 import 'core/result.dart';
 import 'client/request_resolution.dart';
+import 'client/response_policies.dart';
 import 'options.dart';
 import 'pipeline/context.dart';
 import 'pipeline/events.dart';
@@ -22,13 +21,6 @@ import 'transport/default_transport.dart';
 import 'transport/transport.dart';
 
 const Object _jsonOmitted = Object();
-
-final class _StatusBodyPreview {
-  const _StatusBodyPreview({required this.response, this.bodyPreview});
-
-  final Response response;
-  final String? bodyPreview;
-}
 
 /// A reusable HTTP client with shared options, middleware, and transport state.
 ///
@@ -200,7 +192,7 @@ final class Client {
           );
         }
         throwIfLifecycleClosed();
-        final policyResponse = await _applyResponsePolicies(
+        final policyResponse = await applyResponsePolicies(
           prepared,
           response,
           context,
@@ -571,7 +563,7 @@ final class Client {
     Context context,
   ) {
     if (context.redirectPolicy.mode == RedirectMode.follow &&
-        _isRedirectStatus(response.status)) {
+        isRedirectStatus(response.status)) {
       return _runRedirects(request, context, (
         redirectRequest,
         redirectContext,
@@ -580,38 +572,6 @@ final class Client {
       }, firstResponse: response);
     }
     return Future.value(_withResponseTimeouts(response, request, context));
-  }
-
-  Future<Response> _applyResponsePolicies(
-    Request request,
-    Response response,
-    Context context,
-  ) async {
-    if (_isRedirectBlocked(response, context)) {
-      throw StatusError(
-        response,
-        request: request,
-        message: 'Redirect blocked by RedirectPolicy.error.',
-      );
-    }
-
-    if (!context.statusPolicy.accepts(response)) {
-      final preview = await _previewStatusBody(response, context);
-      emitEvent(
-        context.onEvent,
-        RequestEventType.statusFailed,
-        request: request,
-        attempt: context.attempt,
-        response: preview.response,
-      );
-      throw StatusError(
-        preview.response,
-        request: request,
-        bodyPreview: preview.bodyPreview,
-      );
-    }
-
-    return response;
   }
 
   bool _usesClientRedirects(Context context) {
@@ -630,7 +590,7 @@ final class Client {
     var response = firstResponse;
     for (var redirects = 0; ; redirects++) {
       response ??= await next(current, _allowRedirectStatus(context));
-      if (!_isRedirectStatus(response.status)) {
+      if (!isRedirectStatus(response.status)) {
         return redirected ? response.copyWith(redirected: true) : response;
       }
 
@@ -679,7 +639,7 @@ final class Client {
     return context.copyWith(
       statusPolicy: StatusPolicy(
         accept: (response) {
-          return _isRedirectStatus(response.status) ||
+          return isRedirectStatus(response.status) ||
               context.statusPolicy.accepts(response);
         },
       ),
@@ -797,7 +757,7 @@ final class Client {
           response: response,
         );
 
-        if (_isRedirectBlocked(response, attemptContext)) {
+        if (isRedirectBlocked(response, attemptContext)) {
           throw StatusError(
             response,
             request: attemptRequest,
@@ -836,23 +796,11 @@ final class Client {
           continue;
         }
 
-        if (!attemptContext.statusPolicy.accepts(response)) {
-          final preview = await _previewStatusBody(response, attemptContext);
-          emitEvent(
-            attemptContext.onEvent,
-            RequestEventType.statusFailed,
-            request: attemptRequest,
-            attempt: attempt,
-            response: preview.response,
-          );
-          throw StatusError(
-            preview.response,
-            request: attemptRequest,
-            bodyPreview: preview.bodyPreview,
-          );
-        }
-
-        return response;
+        return await applyResponsePolicies(
+          attemptRequest,
+          response,
+          attemptContext,
+        );
       } catch (error, trace) {
         final normalized = _normalizeError(
           error,
@@ -1098,18 +1046,6 @@ final class Client {
     return false;
   }
 
-  bool _isRedirectBlocked(Response response, Context context) {
-    return context.redirectPolicy.mode == RedirectMode.error &&
-        _isRedirectStatus(response.status);
-  }
-
-  bool _isRedirectStatus(int status) {
-    return switch (status) {
-      301 || 302 || 303 || 307 || 308 => true,
-      _ => false,
-    };
-  }
-
   Future<void> _beforeRetry(
     Request request,
     Context context,
@@ -1193,72 +1129,6 @@ final class Client {
       cause: error,
       trace: trace,
     );
-  }
-
-  Future<_StatusBodyPreview> _previewStatusBody(
-    Response response,
-    Context context,
-  ) async {
-    final limit = context.clientOptions.errorBodyPreviewLimit;
-    final body = response.body;
-    if (limit <= 0 || body == null) {
-      return _StatusBodyPreview(response: response);
-    }
-
-    try {
-      final iterator = StreamIterator<Uint8List>(body.open());
-      final chunks = <Uint8List>[];
-      final builder = BytesBuilder(copy: false);
-
-      while (await iterator.moveNext()) {
-        final chunk = iterator.current;
-        chunks.add(chunk);
-        builder.add(chunk);
-        if (builder.length > limit) {
-          if (body.replayable) {
-            await iterator.cancel();
-            return _StatusBodyPreview(response: response);
-          }
-          return _StatusBodyPreview(
-            response: response.copyWith(
-              body: ResponseBody.stream(
-                _restorePreviewStream(chunks, iterator),
-                contentLength: body.contentLength,
-              ),
-            ),
-          );
-        }
-      }
-
-      final data = builder.takeBytes();
-      final next = response.copyWith(body: ResponseBody.fromBytes(data));
-      try {
-        return _StatusBodyPreview(
-          response: next,
-          bodyPreview: utf8.decode(data),
-        );
-      } catch (_) {
-        return _StatusBodyPreview(response: next);
-      }
-    } catch (_) {
-      return _StatusBodyPreview(response: response);
-    }
-  }
-
-  Stream<List<int>> _restorePreviewStream(
-    List<Uint8List> chunks,
-    StreamIterator<Uint8List> iterator,
-  ) async* {
-    try {
-      for (final chunk in chunks) {
-        yield chunk;
-      }
-      while (await iterator.moveNext()) {
-        yield iterator.current;
-      }
-    } finally {
-      await iterator.cancel();
-    }
   }
 }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -7,6 +7,7 @@ import 'core/headers.dart';
 import 'core/request.dart';
 import 'core/response.dart';
 import 'core/result.dart';
+import 'client/error_normalization.dart';
 import 'client/redirects.dart';
 import 'client/request_resolution.dart';
 import 'client/response_policies.dart';
@@ -645,7 +646,7 @@ final class Client {
           attemptContext,
         );
       } catch (error, trace) {
-        final normalized = _normalizeError(
+        final normalized = normalizeRequestError(
           error,
           trace,
           attemptRequest,
@@ -704,45 +705,6 @@ final class Client {
     if (signal?.aborted == true) {
       throw CancelError(reason: signal?.reason, request: request);
     }
-  }
-
-  Object _normalizeError(
-    Object error,
-    StackTrace trace,
-    Request request,
-    Context context,
-  ) {
-    if (context.signal?.aborted == true) {
-      if (context.signal?.reason case final TimeoutError timeoutError) {
-        return timeoutError;
-      }
-      if (error is TimeoutError) {
-        return error;
-      }
-      return CancelError(
-        reason: context.signal?.reason,
-        request: request,
-        trace: trace,
-      );
-    }
-    if (error is RequestError) {
-      return error;
-    }
-    if (error is TimeoutException) {
-      return TimeoutError(
-        phase: TimeoutPhase.total,
-        duration: context.timeoutPolicy.total ?? Duration.zero,
-        request: request,
-        cause: error,
-        trace: trace,
-      );
-    }
-    return NetworkError(
-      error.toString(),
-      request: request,
-      cause: error,
-      trace: trace,
-    );
   }
 }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -4,13 +4,13 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'core/abort.dart';
-import 'core/attributes.dart';
 import 'core/body.dart';
 import 'core/errors.dart';
 import 'core/headers.dart';
 import 'core/request.dart';
 import 'core/response.dart';
 import 'core/result.dart';
+import 'client/request_resolution.dart';
 import 'options.dart';
 import 'pipeline/context.dart';
 import 'pipeline/events.dart';
@@ -113,7 +113,12 @@ final class Client {
       throw NetworkError('Client is closed.', request: request);
     }
 
-    final resolved = _resolve(request, options);
+    final resolved = resolveClientRequest(
+      request,
+      options,
+      clientOptions: this.options,
+      capability: _transport.capability,
+    );
     final prepared = resolved.request;
     var context = resolved.context;
     final totalTimeout = context.timeoutPolicy.total;
@@ -291,7 +296,11 @@ final class Client {
     ProgressCallback? onReceiveProgress,
   }) {
     final requestHeaders = Headers(headers);
-    final requestBody = _resolveBody(body: body, json: json);
+    final requestBody = resolveRequestBody(
+      body: body,
+      json: json,
+      jsonOmitted: _jsonOmitted,
+    );
     if (requestBody?.contentType != null &&
         !requestHeaders.has('content-type')) {
       requestHeaders.set('content-type', requestBody!.contentType!);
@@ -521,78 +530,6 @@ final class Client {
       options: options,
     );
     return response.decode<T>(decoder: decoder);
-  }
-
-  _ResolvedRequest _resolve(Request request, RequestOptions? sendOptions) {
-    final incoming = _mergeRequestOptions(request.options, sendOptions);
-    final timeoutPolicy = incoming.timeoutPolicy ?? options.timeoutPolicy;
-    final retryPolicy = incoming.retryPolicy ?? options.retryPolicy;
-    final redirectPolicy = incoming.redirectPolicy ?? options.redirectPolicy;
-    final statusPolicy = incoming.statusPolicy ?? options.statusPolicy;
-
-    final attributes = _mergeAttributes(
-      options.attributes,
-      request.attributes,
-      incoming.attributes,
-    );
-
-    final context = Context(
-      clientOptions: options,
-      requestOptions: incoming,
-      timeoutPolicy: timeoutPolicy,
-      retryPolicy: retryPolicy,
-      redirectPolicy: redirectPolicy,
-      statusPolicy: statusPolicy,
-      capability: _transport.capability,
-      attributes: attributes,
-      createdAt: DateTime.now().toUtc(),
-      attempt: 0,
-      signal: incoming.signal,
-      onEvent: options.onEvent,
-    );
-
-    final resolvedUrl = _resolveUrl(_mergeQuery(request.uri, incoming.query));
-    final headers = Headers(options.defaultHeaders);
-    for (final name in request.headers.keys()) {
-      headers.delete(name);
-      for (final value in request.headers.getAll(name)) {
-        headers.append(name, value);
-      }
-    }
-    if (incoming.headers != null) {
-      final override = Headers(incoming.headers);
-      for (final name in override.keys()) {
-        headers.delete(name);
-        for (final value in override.getAll(name)) {
-          headers.append(name, value);
-        }
-      }
-    }
-    if (context.capability.name != 'web' &&
-        options.userAgent.isNotEmpty &&
-        !headers.has('user-agent')) {
-      headers.set('user-agent', options.userAgent);
-    }
-
-    final body = request.body;
-    if (body?.contentType != null && !headers.has('content-type')) {
-      headers.set('content-type', body!.contentType!);
-    }
-    if (context.capability.name != 'web' &&
-        body?.contentLength != null &&
-        !headers.has('content-length')) {
-      headers.set('content-length', body!.contentLength!);
-    }
-
-    final prepared = request.copyWith(
-      method: request.method.toUpperCase(),
-      uri: resolvedUrl,
-      headers: headers,
-      options: incoming,
-      attributes: attributes,
-    );
-
-    return _ResolvedRequest(prepared, context);
   }
 
   Future<_ApplicationPipelineResult> _runApplicationPipeline(
@@ -1384,122 +1321,6 @@ final class Client {
       await iterator.cancel();
     }
   }
-
-  RequestOptions _mergeRequestOptions(
-    RequestOptions requestOptions,
-    RequestOptions? sendOptions,
-  ) {
-    if (sendOptions == null) {
-      return requestOptions;
-    }
-
-    return requestOptions.copyWith(
-      headers: sendOptions.headers,
-      query: sendOptions.query,
-      timeoutPolicy: sendOptions.timeoutPolicy,
-      retryPolicy: sendOptions.retryPolicy,
-      redirectPolicy: sendOptions.redirectPolicy,
-      statusPolicy: sendOptions.statusPolicy,
-      middleware: <Middleware>[
-        ...requestOptions.middleware,
-        ...sendOptions.middleware,
-      ],
-      networkMiddleware: <Middleware>[
-        ...requestOptions.networkMiddleware,
-        ...sendOptions.networkMiddleware,
-      ],
-      hooks:
-          requestOptions.hooks?.merge(sendOptions.hooks) ?? sendOptions.hooks,
-      signal: sendOptions.signal,
-      onSendProgress: sendOptions.onSendProgress,
-      onReceiveProgress: sendOptions.onReceiveProgress,
-      attributes: _mergeAttributes(
-        requestOptions.attributes,
-        sendOptions.attributes,
-      ),
-    );
-  }
-
-  Attributes _mergeAttributes(
-    Attributes first,
-    Attributes second, [
-    Attributes third = const Attributes(),
-  ]) {
-    var merged = Attributes(first.toMap());
-    for (final entry in second.toMap().entries) {
-      merged = merged.set(entry.key, entry.value);
-    }
-    for (final entry in third.toMap().entries) {
-      merged = merged.set(entry.key, entry.value);
-    }
-    return merged;
-  }
-
-  Uri _resolveUrl(Uri url) {
-    if (url.hasScheme) {
-      return url;
-    }
-    final baseUrl = options.baseUrl;
-    if (baseUrl == null) {
-      throw ArgumentError.value(
-        url.toString(),
-        'url',
-        'Relative URLs require ClientOptions(baseUrl: ...).',
-      );
-    }
-    return baseUrl.resolveUri(url);
-  }
-
-  Uri _mergeQuery(Uri uri, QueryMap? query) {
-    if (query == null || query.isEmpty) {
-      return uri;
-    }
-
-    final merged = <String, List<String>>{
-      for (final entry in uri.queryParametersAll.entries)
-        entry.key: List<String>.from(entry.value),
-    };
-
-    for (final entry in query.entries) {
-      final value = entry.value;
-      if (value == null) {
-        continue;
-      }
-      if (value is Iterable && value is! String) {
-        merged[entry.key] = value.map((item) => item.toString()).toList();
-      } else {
-        merged[entry.key] = <String>[value.toString()];
-      }
-    }
-
-    final parts = <String>[];
-    for (final entry in merged.entries) {
-      for (final value in entry.value) {
-        parts.add(
-          '${Uri.encodeQueryComponent(entry.key)}='
-          '${Uri.encodeQueryComponent(value)}',
-        );
-      }
-    }
-    return uri.replace(query: parts.join('&'));
-  }
-
-  Body? _resolveBody({required Object? body, required Object? json}) {
-    if (body != null && !identical(json, _jsonOmitted)) {
-      throw ArgumentError('Use either body or json, not both.');
-    }
-    if (!identical(json, _jsonOmitted)) {
-      return Body.fromJson(json);
-    }
-    return Body.from(body);
-  }
-}
-
-final class _ResolvedRequest {
-  const _ResolvedRequest(this.request, this.context);
-
-  final Request request;
-  final Context context;
 }
 
 final class _ApplicationPipelineResult {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -8,12 +8,12 @@ import 'core/headers.dart';
 import 'core/request.dart';
 import 'core/response.dart';
 import 'core/result.dart';
+import 'client/redirects.dart';
 import 'client/request_resolution.dart';
 import 'client/response_policies.dart';
 import 'options.dart';
 import 'pipeline/context.dart';
 import 'pipeline/events.dart';
-import 'pipeline/internal_attributes.dart';
 import 'pipeline/middleware.dart';
 import 'pipeline/runner.dart';
 import 'policies.dart';
@@ -540,8 +540,8 @@ final class Client {
       nextContext,
     ) {
       reachedTerminal = true;
-      if (_usesClientRedirects(nextContext)) {
-        return _runRedirects(nextRequest, nextContext, (
+      if (usesClientRedirects(nextContext)) {
+        return runRedirects(nextRequest, nextContext, (
           redirectRequest,
           redirectContext,
         ) {
@@ -564,146 +564,11 @@ final class Client {
   ) {
     if (context.redirectPolicy.mode == RedirectMode.follow &&
         isRedirectStatus(response.status)) {
-      return _runRedirects(request, context, (
-        redirectRequest,
-        redirectContext,
-      ) {
+      return runRedirects(request, context, (redirectRequest, redirectContext) {
         return _runOperation(redirectRequest, redirectContext);
       }, firstResponse: response);
     }
     return Future.value(_withResponseTimeouts(response, request, context));
-  }
-
-  bool _usesClientRedirects(Context context) {
-    return context.redirectPolicy.mode == RedirectMode.follow &&
-        context.capability.name != 'web';
-  }
-
-  Future<Response> _runRedirects(
-    Request request,
-    Context context,
-    Next next, {
-    Response? firstResponse,
-  }) async {
-    var current = request;
-    var redirected = false;
-    var response = firstResponse;
-    for (var redirects = 0; ; redirects++) {
-      response ??= await next(current, _allowRedirectStatus(context));
-      if (!isRedirectStatus(response.status)) {
-        return redirected ? response.copyWith(redirected: true) : response;
-      }
-
-      final location = response.headers.get('location');
-      if (location == null || location.trim().isEmpty) {
-        throw StatusError(
-          response,
-          request: current,
-          message: 'Redirect response is missing a Location header.',
-        );
-      }
-      if (redirects >= context.redirectPolicy.maxRedirects) {
-        throw StatusError(
-          response,
-          request: current,
-          message: 'Too many redirects.',
-        );
-      }
-      if (!_redirectChangesToGet(response.status, current.method) &&
-          current.body?.replayable == false) {
-        await response.drain(maxBytes: null);
-        throw StatusError(
-          response,
-          request: current,
-          message: 'Redirect requires a replayable request body.',
-        );
-      }
-
-      await response.drain(maxBytes: null);
-      try {
-        current = _redirectRequest(current, response, location);
-      } on FormatException catch (_, trace) {
-        throw StatusError(
-          response,
-          request: current,
-          message: 'Redirect response has an invalid Location header.',
-          trace: trace,
-        );
-      }
-      redirected = true;
-      response = null;
-    }
-  }
-
-  Context _allowRedirectStatus(Context context) {
-    return context.copyWith(
-      statusPolicy: StatusPolicy(
-        accept: (response) {
-          return isRedirectStatus(response.status) ||
-              context.statusPolicy.accepts(response);
-        },
-      ),
-    );
-  }
-
-  Request _redirectRequest(
-    Request request,
-    Response response,
-    String location,
-  ) {
-    final base = response.url.hasScheme ? response.url : request.uri;
-    final nextUri = base.resolve(location);
-    final sameOrigin = _sameOrigin(request.uri, nextUri);
-    final nextHeaders = request.headers.copy();
-    var nextAttributes = request.attributes;
-    if (!sameOrigin) {
-      nextHeaders.delete('authorization');
-      nextHeaders.delete('cookie');
-      nextHeaders.delete('proxy-authorization');
-      nextAttributes = nextAttributes
-          .remove(cookieHeaderManagedAttribute)
-          .set(redirectCrossOriginAttribute, true);
-    }
-
-    var method = request.method;
-    var clearBody = false;
-    if (_redirectChangesToGet(response.status, method)) {
-      method = 'GET';
-      clearBody = true;
-      nextHeaders.delete('content-length');
-      nextHeaders.delete('content-type');
-    }
-
-    return request.copyWith(
-      method: method,
-      uri: nextUri,
-      headers: nextHeaders,
-      clearBody: clearBody,
-      attributes: nextAttributes,
-    );
-  }
-
-  bool _redirectChangesToGet(int status, String method) {
-    final upper = method.toUpperCase();
-    if (status == 303 && upper != 'GET' && upper != 'HEAD') {
-      return true;
-    }
-    return (status == 301 || status == 302) && upper == 'POST';
-  }
-
-  bool _sameOrigin(Uri a, Uri b) {
-    return a.scheme == b.scheme && a.host == b.host && _portOf(a) == _portOf(b);
-  }
-
-  int _portOf(Uri uri) {
-    if (uri.hasPort) {
-      return uri.port;
-    }
-    return switch (uri.scheme) {
-      'http' => 80,
-      'https' => 443,
-      _ => 0,
-    };
   }
 
   Future<Response> _runOperation(Request request, Context context) async {
@@ -717,7 +582,7 @@ final class Client {
         attempt: attempt,
         signal: attemptSignal,
       );
-      final attemptRequest = _sanitizeRedirectHeaders(request);
+      final attemptRequest = sanitizeRedirectHeaders(request);
 
       if (attempt > 0 && request.body != null && !request.body!.replayable) {
         attemptContext.emit(
@@ -842,20 +707,6 @@ final class Client {
     }
   }
 
-  Request _sanitizeRedirectHeaders(Request request) {
-    if (request.attributes.get(redirectCrossOriginAttribute) != true) {
-      return request;
-    }
-
-    final headers = request.headers.copy()
-      ..delete('authorization')
-      ..delete('proxy-authorization');
-    if (request.attributes.get(cookieHeaderManagedAttribute) != true) {
-      headers.delete('cookie');
-    }
-    return request.copyWith(headers: headers);
-  }
-
   Future<Response> _runNetworkPipeline(Request request, Context context) {
     final middleware = combineMiddleware(
       options.networkMiddleware,
@@ -866,10 +717,7 @@ final class Client {
       nextRequest,
       nextContext,
     ) {
-      return _transport.send(
-        _sanitizeRedirectHeaders(nextRequest),
-        nextContext,
-      );
+      return _transport.send(sanitizeRedirectHeaders(nextRequest), nextContext);
     })(request, context);
     return operation;
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'core/abort.dart';
-import 'core/body.dart';
 import 'core/errors.dart';
 import 'core/headers.dart';
 import 'core/request.dart';
@@ -12,6 +11,7 @@ import 'client/redirects.dart';
 import 'client/request_resolution.dart';
 import 'client/response_policies.dart';
 import 'client/retry.dart';
+import 'client/timeouts.dart';
 import 'options.dart';
 import 'pipeline/context.dart';
 import 'pipeline/events.dart';
@@ -116,8 +116,8 @@ final class Client {
     final prepared = resolved.request;
     var context = resolved.context;
     final totalTimeout = context.timeoutPolicy.total;
-    final timeoutSignal = _needsInternalSignal(context.timeoutPolicy)
-        ? _linkedSignal(context.signal)
+    final timeoutSignal = needsInternalSignal(context.timeoutPolicy)
+        ? linkedSignal(context.signal)
         : null;
     if (timeoutSignal != null) {
       context = context.copyWith(signal: timeoutSignal);
@@ -237,29 +237,6 @@ final class Client {
         });
       },
     );
-  }
-
-  AbortSignal _linkedSignal(AbortSignal? parent) {
-    final signal = AbortSignal();
-    if (parent == null) {
-      return signal;
-    }
-
-    if (parent.aborted) {
-      signal.abort(parent.reason);
-    } else {
-      parent.onAbort(() {
-        signal.abort(parent.reason);
-      });
-    }
-    return signal;
-  }
-
-  bool _needsInternalSignal(TimeoutPolicy policy) {
-    return policy.total != null ||
-        policy.send != null ||
-        policy.firstByte != null ||
-        policy.read != null;
   }
 
   /// Sends [request] and captures success or failure in a [Result].
@@ -569,7 +546,7 @@ final class Client {
         return _runOperation(redirectRequest, redirectContext);
       }, firstResponse: response);
     }
-    return Future.value(_withResponseTimeouts(response, request, context));
+    return Future.value(withResponseTimeouts(response, request, context));
   }
 
   Future<Response> _runOperation(Request request, Context context) async {
@@ -578,7 +555,7 @@ final class Client {
     Response? lastResponse;
 
     for (var attempt = 0; ; attempt++) {
-      final attemptSignal = _linkedSignal(context.signal);
+      final attemptSignal = linkedSignal(context.signal);
       final attemptContext = context.copyWith(
         attempt: attempt,
         signal: attemptSignal,
@@ -612,8 +589,8 @@ final class Client {
           attemptRequest,
           attemptContext,
         );
-        response = _withReadTimeout(response, attemptRequest, attemptContext);
-        response = _withTotalTimeout(response, attemptRequest, attemptContext);
+        response = withReadTimeout(response, attemptRequest, attemptContext);
+        response = withTotalTimeout(response, attemptRequest, attemptContext);
 
         emitEvent(
           attemptContext.onEvent,
@@ -727,139 +704,6 @@ final class Client {
     if (signal?.aborted == true) {
       throw CancelError(reason: signal?.reason, request: request);
     }
-  }
-
-  Response _withReadTimeout(
-    Response response,
-    Request request,
-    Context context,
-  ) {
-    final timeout = context.timeoutPolicy.read;
-    final body = response.body;
-    if (timeout == null || body == null || body.replayable) {
-      return response;
-    }
-
-    return response.copyWith(
-      body: ResponseBody.stream(
-        _readTimeoutStream(body.open(), timeout, request),
-        contentLength: body.contentLength,
-      ),
-    );
-  }
-
-  Response _withResponseTimeouts(
-    Response response,
-    Request request,
-    Context context,
-  ) {
-    return _withTotalTimeout(
-      _withReadTimeout(response, request, context),
-      request,
-      context,
-    );
-  }
-
-  Response _withTotalTimeout(
-    Response response,
-    Request request,
-    Context context,
-  ) {
-    final timeout = context.timeoutPolicy.total;
-    final body = response.body;
-    if (timeout == null || body == null || body.replayable) {
-      return response;
-    }
-
-    final deadline = context.createdAt.add(timeout);
-    return response.copyWith(
-      body: ResponseBody.stream(
-        _totalTimeoutStream(
-          body.open(),
-          timeout,
-          deadline,
-          request,
-          context.signal,
-        ),
-        contentLength: body.contentLength,
-      ),
-    );
-  }
-
-  Stream<List<int>> _readTimeoutStream(
-    Stream<List<int>> source,
-    Duration timeout,
-    Request request,
-  ) async* {
-    final iterator = StreamIterator<List<int>>(source);
-    try {
-      while (true) {
-        final hasNext = await iterator.moveNext().timeout(
-          timeout,
-          onTimeout: () {
-            final timeoutError = TimeoutError(
-              phase: TimeoutPhase.read,
-              duration: timeout,
-              request: request,
-              sent: true,
-            );
-            throw timeoutError;
-          },
-        );
-        if (!hasNext) {
-          break;
-        }
-        yield iterator.current;
-      }
-    } finally {
-      await iterator.cancel();
-    }
-  }
-
-  Stream<List<int>> _totalTimeoutStream(
-    Stream<List<int>> source,
-    Duration timeout,
-    DateTime deadline,
-    Request request,
-    AbortSignal? signal,
-  ) async* {
-    final iterator = StreamIterator<List<int>>(source);
-    try {
-      while (true) {
-        final remaining = deadline.difference(DateTime.now().toUtc());
-        if (remaining <= Duration.zero) {
-          throw _abortTotalTimeout(timeout, request, signal);
-        }
-
-        final hasNext = await iterator.moveNext().timeout(
-          remaining,
-          onTimeout: () {
-            throw _abortTotalTimeout(timeout, request, signal);
-          },
-        );
-        if (!hasNext) {
-          break;
-        }
-        yield iterator.current;
-      }
-    } finally {
-      await iterator.cancel();
-    }
-  }
-
-  TimeoutError _abortTotalTimeout(
-    Duration timeout,
-    Request request,
-    AbortSignal? signal,
-  ) {
-    final timeoutError = TimeoutError(
-      phase: TimeoutPhase.total,
-      duration: timeout,
-      request: request,
-      sent: true,
-    );
-    signal?.abort(timeoutError);
-    return timeoutError;
   }
 
   Object _normalizeError(

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -16,6 +16,7 @@ import 'pipeline/context.dart';
 import 'pipeline/events.dart';
 import 'pipeline/internal_attributes.dart';
 import 'pipeline/middleware.dart';
+import 'pipeline/runner.dart';
 import 'policies.dart';
 import 'transport/default_transport.dart';
 import 'transport/transport.dart';
@@ -536,13 +537,16 @@ final class Client {
     Request request,
     Context context,
   ) async {
-    final middleware = <Middleware>[
-      ...options.middleware,
-      ...context.requestOptions.middleware,
-    ];
+    final middleware = combineMiddleware(
+      options.middleware,
+      context.requestOptions.middleware,
+    );
 
     var reachedTerminal = false;
-    final next = _buildPipeline(middleware, (nextRequest, nextContext) {
+    final next = buildMiddlewarePipeline(middleware, (
+      nextRequest,
+      nextContext,
+    ) {
       reachedTerminal = true;
       if (_usesClientRedirects(nextContext)) {
         return _runRedirects(nextRequest, nextContext, (
@@ -905,12 +909,15 @@ final class Client {
   }
 
   Future<Response> _runNetworkPipeline(Request request, Context context) {
-    final middleware = <Middleware>[
-      ...options.networkMiddleware,
-      ...context.requestOptions.networkMiddleware,
-    ];
+    final middleware = combineMiddleware(
+      options.networkMiddleware,
+      context.requestOptions.networkMiddleware,
+    );
 
-    final operation = _buildPipeline(middleware, (nextRequest, nextContext) {
+    final operation = buildMiddlewarePipeline(middleware, (
+      nextRequest,
+      nextContext,
+    ) {
       return _transport.send(
         _sanitizeRedirectHeaders(nextRequest),
         nextContext,
@@ -1056,74 +1063,6 @@ final class Client {
     );
     signal?.abort(timeoutError);
     return timeoutError;
-  }
-
-  Next _buildPipeline(List<Middleware> middleware, Next terminal) {
-    Next runner = terminal;
-
-    for (var i = middleware.length - 1; i >= 0; i--) {
-      final current = middleware[i];
-      final next = runner;
-      runner = (request, context) async {
-        final middlewareName = current.runtimeType.toString();
-        Future<Response> guardedNext(Request request, Context context) async {
-          try {
-            return await next(request, context);
-          } catch (error, trace) {
-            if (error is RequestError) {
-              Error.throwWithStackTrace(error, trace);
-            }
-            throw _DownstreamError(error, trace);
-          }
-        }
-
-        void emitMiddlewareEnd({Response? response, Object? error}) {
-          emitEvent(
-            context.onEvent,
-            RequestEventType.middlewareEnd,
-            request: request,
-            attempt: context.attempt,
-            response: response,
-            error: error,
-            detail: middlewareName,
-          );
-        }
-
-        emitEvent(
-          context.onEvent,
-          RequestEventType.middlewareStart,
-          request: request,
-          attempt: context.attempt,
-          detail: middlewareName,
-        );
-        late Response response;
-        try {
-          response = await current.intercept(request, context, guardedNext);
-        } catch (error, trace) {
-          if (error is _DownstreamError) {
-            emitMiddlewareEnd(error: error.error);
-            Error.throwWithStackTrace(error.error, error.trace);
-          }
-          if (error is RequestError) {
-            emitMiddlewareEnd(error: error);
-            rethrow;
-          }
-          final middlewareError = MiddlewareError(
-            middleware: middlewareName,
-            message: 'Middleware execution failed.',
-            request: request,
-            cause: error,
-            trace: trace,
-          );
-          emitMiddlewareEnd(error: middlewareError);
-          throw middlewareError;
-        }
-        emitMiddlewareEnd(response: response);
-        return response;
-      };
-    }
-
-    return runner;
   }
 
   bool _shouldRetryResponse(
@@ -1331,13 +1270,6 @@ final class _ApplicationPipelineResult {
 
   final Response response;
   final bool reachedTerminal;
-}
-
-final class _DownstreamError {
-  const _DownstreamError(this.error, this.trace);
-
-  final Object error;
-  final StackTrace trace;
 }
 
 /// The shared client used by [fetch] and [fetchResult].

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,6 +11,7 @@ import 'core/result.dart';
 import 'client/redirects.dart';
 import 'client/request_resolution.dart';
 import 'client/response_policies.dart';
+import 'client/retry.dart';
 import 'options.dart';
 import 'pipeline/context.dart';
 import 'pipeline/events.dart';
@@ -630,7 +631,7 @@ final class Client {
           );
         }
 
-        if (_shouldRetryResponse(attemptRequest, response, attemptContext)) {
+        if (shouldRetryResponse(attemptRequest, response, attemptContext)) {
           lastResponse = response;
           if (attempt >= retryPolicy.maxRetries) {
             throw RetryError(
@@ -650,14 +651,14 @@ final class Client {
             signal: context.signal,
             clearSignal: context.signal == null,
           );
-          await _beforeRetry(
+          await beforeRetry(
             attemptRequest,
             retryContext,
             null,
             response,
             delay,
           );
-          await _waitRetryDelay(delay, retryContext);
+          await waitRetryDelay(delay, retryContext);
           continue;
         }
 
@@ -675,7 +676,7 @@ final class Client {
         );
         lastError = normalized;
 
-        if (_shouldRetryError(attemptRequest, normalized, attemptContext)) {
+        if (shouldRetryError(attemptRequest, normalized, attemptContext)) {
           if (attempt >= retryPolicy.maxRetries) {
             throw RetryError(
               attempts: attempt + 1,
@@ -691,14 +692,14 @@ final class Client {
             signal: context.signal,
             clearSignal: context.signal == null,
           );
-          await _beforeRetry(
+          await beforeRetry(
             attemptRequest,
             retryContext,
             normalized,
             null,
             delay,
           );
-          await _waitRetryDelay(delay, retryContext);
+          await waitRetryDelay(delay, retryContext);
           continue;
         }
 
@@ -859,85 +860,6 @@ final class Client {
     );
     signal?.abort(timeoutError);
     return timeoutError;
-  }
-
-  bool _shouldRetryResponse(
-    Request request,
-    Response response,
-    Context context,
-  ) {
-    final policy = context.retryPolicy;
-    if (policy.maxRetries <= 0 ||
-        !policy.allowsMethod(request) ||
-        request.body?.replayable == false) {
-      return false;
-    }
-    return policy.shouldRetryResponse(response);
-  }
-
-  bool _shouldRetryError(Request request, Object error, Context context) {
-    final policy = context.retryPolicy;
-    if (policy.maxRetries <= 0 ||
-        !policy.allowsMethod(request) ||
-        request.body?.replayable == false) {
-      return false;
-    }
-    if (error is CancelError || error is DecodeError) {
-      return false;
-    }
-    if (error is TimeoutError) {
-      return error.retryable;
-    }
-    if (error is NetworkError) {
-      return error.retryable;
-    }
-    return false;
-  }
-
-  Future<void> _beforeRetry(
-    Request request,
-    Context context,
-    Object? error,
-    Response? response,
-    Duration delay,
-  ) async {
-    emitEvent(
-      context.onEvent,
-      RequestEventType.retryScheduled,
-      request: request,
-      attempt: context.attempt,
-      response: response,
-      error: error,
-      detail: delay.toString(),
-    );
-    await context.clientOptions.hooks
-        .merge(context.requestOptions.hooks)
-        .onRetry
-        ?.call(request, error, response, delay, context);
-  }
-
-  Future<void> _waitRetryDelay(Duration delay, Context context) {
-    final signal = context.signal;
-    if (signal == null) {
-      return Future<void>.delayed(delay);
-    }
-    if (signal.aborted) {
-      throw CancelError(reason: signal.reason);
-    }
-
-    final completer = Completer<void>();
-    final timer = Timer(delay, () {
-      if (!completer.isCompleted) {
-        completer.complete();
-      }
-    });
-    signal.onAbort(() {
-      timer.cancel();
-      if (!completer.isCompleted) {
-        completer.completeError(CancelError(reason: signal.reason));
-      }
-    });
-    return completer.future;
   }
 
   Object _normalizeError(

--- a/lib/src/client/error_normalization.dart
+++ b/lib/src/client/error_normalization.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../pipeline/context.dart';
+
+Object normalizeRequestError(
+  Object error,
+  StackTrace trace,
+  Request request,
+  Context context,
+) {
+  if (context.signal?.aborted == true) {
+    if (context.signal?.reason case final TimeoutError timeoutError) {
+      return timeoutError;
+    }
+    if (error is TimeoutError) {
+      return error;
+    }
+    return CancelError(
+      reason: context.signal?.reason,
+      request: request,
+      trace: trace,
+    );
+  }
+  if (error is RequestError) {
+    return error;
+  }
+  if (error is TimeoutException) {
+    return TimeoutError(
+      phase: TimeoutPhase.total,
+      duration: context.timeoutPolicy.total ?? Duration.zero,
+      request: request,
+      cause: error,
+      trace: trace,
+    );
+  }
+  return NetworkError(
+    error.toString(),
+    request: request,
+    cause: error,
+    trace: trace,
+  );
+}

--- a/lib/src/client/redirects.dart
+++ b/lib/src/client/redirects.dart
@@ -1,0 +1,150 @@
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../core/response.dart';
+import '../pipeline/context.dart';
+import '../pipeline/internal_attributes.dart';
+import '../pipeline/middleware.dart';
+import '../policies.dart';
+import 'response_policies.dart';
+
+bool usesClientRedirects(Context context) {
+  return context.redirectPolicy.mode == RedirectMode.follow &&
+      context.capability.name != 'web';
+}
+
+Future<Response> runRedirects(
+  Request request,
+  Context context,
+  Next next, {
+  Response? firstResponse,
+}) async {
+  var current = request;
+  var redirected = false;
+  var response = firstResponse;
+  for (var redirects = 0; ; redirects++) {
+    response ??= await next(current, _allowRedirectStatus(context));
+    if (!isRedirectStatus(response.status)) {
+      return redirected ? response.copyWith(redirected: true) : response;
+    }
+
+    final location = response.headers.get('location');
+    if (location == null || location.trim().isEmpty) {
+      throw StatusError(
+        response,
+        request: current,
+        message: 'Redirect response is missing a Location header.',
+      );
+    }
+    if (redirects >= context.redirectPolicy.maxRedirects) {
+      throw StatusError(
+        response,
+        request: current,
+        message: 'Too many redirects.',
+      );
+    }
+    if (!_redirectChangesToGet(response.status, current.method) &&
+        current.body?.replayable == false) {
+      await response.drain(maxBytes: null);
+      throw StatusError(
+        response,
+        request: current,
+        message: 'Redirect requires a replayable request body.',
+      );
+    }
+
+    await response.drain(maxBytes: null);
+    try {
+      current = _redirectRequest(current, response, location);
+    } on FormatException catch (_, trace) {
+      throw StatusError(
+        response,
+        request: current,
+        message: 'Redirect response has an invalid Location header.',
+        trace: trace,
+      );
+    }
+    redirected = true;
+    response = null;
+  }
+}
+
+Request sanitizeRedirectHeaders(Request request) {
+  if (request.attributes.get(redirectCrossOriginAttribute) != true) {
+    return request;
+  }
+
+  final headers = request.headers.copy()
+    ..delete('authorization')
+    ..delete('proxy-authorization');
+  if (request.attributes.get(cookieHeaderManagedAttribute) != true) {
+    headers.delete('cookie');
+  }
+  return request.copyWith(headers: headers);
+}
+
+Context _allowRedirectStatus(Context context) {
+  return context.copyWith(
+    statusPolicy: StatusPolicy(
+      accept: (response) {
+        return isRedirectStatus(response.status) ||
+            context.statusPolicy.accepts(response);
+      },
+    ),
+  );
+}
+
+Request _redirectRequest(Request request, Response response, String location) {
+  final base = response.url.hasScheme ? response.url : request.uri;
+  final nextUri = base.resolve(location);
+  final sameOrigin = _sameOrigin(request.uri, nextUri);
+  final nextHeaders = request.headers.copy();
+  var nextAttributes = request.attributes;
+  if (!sameOrigin) {
+    nextHeaders.delete('authorization');
+    nextHeaders.delete('cookie');
+    nextHeaders.delete('proxy-authorization');
+    nextAttributes = nextAttributes
+        .remove(cookieHeaderManagedAttribute)
+        .set(redirectCrossOriginAttribute, true);
+  }
+
+  var method = request.method;
+  var clearBody = false;
+  if (_redirectChangesToGet(response.status, method)) {
+    method = 'GET';
+    clearBody = true;
+    nextHeaders.delete('content-length');
+    nextHeaders.delete('content-type');
+  }
+
+  return request.copyWith(
+    method: method,
+    uri: nextUri,
+    headers: nextHeaders,
+    clearBody: clearBody,
+    attributes: nextAttributes,
+  );
+}
+
+bool _redirectChangesToGet(int status, String method) {
+  final upper = method.toUpperCase();
+  if (status == 303 && upper != 'GET' && upper != 'HEAD') {
+    return true;
+  }
+  return (status == 301 || status == 302) && upper == 'POST';
+}
+
+bool _sameOrigin(Uri a, Uri b) {
+  return a.scheme == b.scheme && a.host == b.host && _portOf(a) == _portOf(b);
+}
+
+int _portOf(Uri uri) {
+  if (uri.hasPort) {
+    return uri.port;
+  }
+  return switch (uri.scheme) {
+    'http' => 80,
+    'https' => 443,
+    _ => 0,
+  };
+}

--- a/lib/src/client/request_resolution.dart
+++ b/lib/src/client/request_resolution.dart
@@ -1,0 +1,214 @@
+import '../core/attributes.dart';
+import '../core/body.dart';
+import '../core/headers.dart';
+import '../core/request.dart';
+import '../options.dart';
+import '../pipeline/context.dart';
+import '../pipeline/middleware.dart';
+import '../transport/capability.dart';
+
+final class ResolvedRequest {
+  const ResolvedRequest(this.request, this.context);
+
+  final Request request;
+  final Context context;
+}
+
+ResolvedRequest resolveClientRequest(
+  Request request,
+  RequestOptions? sendOptions, {
+  required ClientOptions clientOptions,
+  required PlatformCapability capability,
+}) {
+  final incoming = _mergeRequestOptions(request.options, sendOptions);
+  final timeoutPolicy = incoming.timeoutPolicy ?? clientOptions.timeoutPolicy;
+  final retryPolicy = incoming.retryPolicy ?? clientOptions.retryPolicy;
+  final redirectPolicy =
+      incoming.redirectPolicy ?? clientOptions.redirectPolicy;
+  final statusPolicy = incoming.statusPolicy ?? clientOptions.statusPolicy;
+
+  final attributes = _mergeAttributes(
+    clientOptions.attributes,
+    request.attributes,
+    incoming.attributes,
+  );
+
+  final context = Context(
+    clientOptions: clientOptions,
+    requestOptions: incoming,
+    timeoutPolicy: timeoutPolicy,
+    retryPolicy: retryPolicy,
+    redirectPolicy: redirectPolicy,
+    statusPolicy: statusPolicy,
+    capability: capability,
+    attributes: attributes,
+    createdAt: DateTime.now().toUtc(),
+    attempt: 0,
+    signal: incoming.signal,
+    onEvent: clientOptions.onEvent,
+  );
+
+  final resolvedUrl = _resolveUrl(
+    _mergeQuery(request.uri, incoming.query),
+    clientOptions.baseUrl,
+  );
+  final headers = Headers(clientOptions.defaultHeaders);
+  for (final name in request.headers.keys()) {
+    headers.delete(name);
+    for (final value in request.headers.getAll(name)) {
+      headers.append(name, value);
+    }
+  }
+  if (incoming.headers != null) {
+    final override = Headers(incoming.headers);
+    for (final name in override.keys()) {
+      headers.delete(name);
+      for (final value in override.getAll(name)) {
+        headers.append(name, value);
+      }
+    }
+  }
+  if (capability.name != 'web' &&
+      clientOptions.userAgent.isNotEmpty &&
+      !headers.has('user-agent')) {
+    headers.set('user-agent', clientOptions.userAgent);
+  }
+
+  final body = request.body;
+  if (body?.contentType != null && !headers.has('content-type')) {
+    headers.set('content-type', body!.contentType!);
+  }
+  if (capability.name != 'web' &&
+      body?.contentLength != null &&
+      !headers.has('content-length')) {
+    headers.set('content-length', body!.contentLength!);
+  }
+
+  final prepared = request.copyWith(
+    method: request.method.toUpperCase(),
+    uri: resolvedUrl,
+    headers: headers,
+    options: incoming,
+    attributes: attributes,
+  );
+
+  return ResolvedRequest(prepared, context);
+}
+
+Body? resolveRequestBody({
+  required Object? body,
+  required Object? json,
+  required Object jsonOmitted,
+}) {
+  if (body != null && !identical(json, jsonOmitted)) {
+    throw ArgumentError('Use either body or json, not both.');
+  }
+  if (!identical(json, jsonOmitted)) {
+    return Body.fromJson(json);
+  }
+  return Body.from(body);
+}
+
+RequestOptions _mergeRequestOptions(
+  RequestOptions requestOptions,
+  RequestOptions? sendOptions,
+) {
+  if (sendOptions == null) {
+    return requestOptions;
+  }
+
+  return requestOptions.copyWith(
+    headers: sendOptions.headers,
+    query: sendOptions.query,
+    timeoutPolicy: sendOptions.timeoutPolicy,
+    retryPolicy: sendOptions.retryPolicy,
+    redirectPolicy: sendOptions.redirectPolicy,
+    statusPolicy: sendOptions.statusPolicy,
+    middleware: <Middleware>[
+      ...requestOptions.middleware,
+      ...sendOptions.middleware,
+    ],
+    networkMiddleware: <Middleware>[
+      ...requestOptions.networkMiddleware,
+      ...sendOptions.networkMiddleware,
+    ],
+    hooks: requestOptions.hooks?.merge(sendOptions.hooks) ?? sendOptions.hooks,
+    signal: sendOptions.signal,
+    onSendProgress: sendOptions.onSendProgress,
+    onReceiveProgress: sendOptions.onReceiveProgress,
+    attributes: _mergeAttributes(
+      requestOptions.attributes,
+      sendOptions.attributes,
+    ),
+  );
+}
+
+Attributes _mergeAttributes(
+  Attributes first,
+  Attributes second, [
+  Attributes third = const Attributes(),
+]) {
+  if (second.isEmpty && third.isEmpty) {
+    return first;
+  }
+
+  final merged = <AttributeKey<Object>, Object>{};
+  if (first.isNotEmpty) {
+    merged.addAll(first.toMap());
+  }
+  if (second.isNotEmpty) {
+    merged.addAll(second.toMap());
+  }
+  if (third.isNotEmpty) {
+    merged.addAll(third.toMap());
+  }
+  return Attributes(merged);
+}
+
+Uri _resolveUrl(Uri url, Uri? baseUrl) {
+  if (url.hasScheme) {
+    return url;
+  }
+  if (baseUrl == null) {
+    throw ArgumentError.value(
+      url.toString(),
+      'url',
+      'Relative URLs require ClientOptions(baseUrl: ...).',
+    );
+  }
+  return baseUrl.resolveUri(url);
+}
+
+Uri _mergeQuery(Uri uri, QueryMap? query) {
+  if (query == null || query.isEmpty) {
+    return uri;
+  }
+
+  final merged = <String, List<String>>{
+    for (final entry in uri.queryParametersAll.entries)
+      entry.key: List<String>.from(entry.value),
+  };
+
+  for (final entry in query.entries) {
+    final value = entry.value;
+    if (value == null) {
+      continue;
+    }
+    if (value is Iterable && value is! String) {
+      merged[entry.key] = value.map((item) => item.toString()).toList();
+    } else {
+      merged[entry.key] = <String>[value.toString()];
+    }
+  }
+
+  final parts = <String>[];
+  for (final entry in merged.entries) {
+    for (final value in entry.value) {
+      parts.add(
+        '${Uri.encodeQueryComponent(entry.key)}='
+        '${Uri.encodeQueryComponent(value)}',
+      );
+    }
+  }
+  return uri.replace(query: parts.join('&'));
+}

--- a/lib/src/client/response_policies.dart
+++ b/lib/src/client/response_policies.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../core/body.dart';
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../core/response.dart';
+import '../pipeline/context.dart';
+import '../pipeline/events.dart';
+import '../policies.dart';
+
+Future<Response> applyResponsePolicies(
+  Request request,
+  Response response,
+  Context context,
+) async {
+  if (isRedirectBlocked(response, context)) {
+    throw StatusError(
+      response,
+      request: request,
+      message: 'Redirect blocked by RedirectPolicy.error.',
+    );
+  }
+
+  if (!context.statusPolicy.accepts(response)) {
+    final preview = await _previewStatusBody(response, context);
+    emitEvent(
+      context.onEvent,
+      RequestEventType.statusFailed,
+      request: request,
+      attempt: context.attempt,
+      response: preview.response,
+    );
+    throw StatusError(
+      preview.response,
+      request: request,
+      bodyPreview: preview.bodyPreview,
+    );
+  }
+
+  return response;
+}
+
+bool isRedirectBlocked(Response response, Context context) {
+  return context.redirectPolicy.mode == RedirectMode.error &&
+      isRedirectStatus(response.status);
+}
+
+bool isRedirectStatus(int status) {
+  return switch (status) {
+    301 || 302 || 303 || 307 || 308 => true,
+    _ => false,
+  };
+}
+
+Future<_StatusBodyPreview> _previewStatusBody(
+  Response response,
+  Context context,
+) async {
+  final limit = context.clientOptions.errorBodyPreviewLimit;
+  final body = response.body;
+  if (limit <= 0 || body == null) {
+    return _StatusBodyPreview(response: response);
+  }
+
+  try {
+    final iterator = StreamIterator<Uint8List>(body.open());
+    final chunks = <Uint8List>[];
+    final builder = BytesBuilder(copy: false);
+
+    while (await iterator.moveNext()) {
+      final chunk = iterator.current;
+      chunks.add(chunk);
+      builder.add(chunk);
+      if (builder.length > limit) {
+        if (body.replayable) {
+          await iterator.cancel();
+          return _StatusBodyPreview(response: response);
+        }
+        return _StatusBodyPreview(
+          response: response.copyWith(
+            body: ResponseBody.stream(
+              _restorePreviewStream(chunks, iterator),
+              contentLength: body.contentLength,
+            ),
+          ),
+        );
+      }
+    }
+
+    final data = builder.takeBytes();
+    final next = response.copyWith(body: ResponseBody.fromBytes(data));
+    try {
+      return _StatusBodyPreview(response: next, bodyPreview: utf8.decode(data));
+    } catch (_) {
+      return _StatusBodyPreview(response: next);
+    }
+  } catch (_) {
+    return _StatusBodyPreview(response: response);
+  }
+}
+
+Stream<List<int>> _restorePreviewStream(
+  List<Uint8List> chunks,
+  StreamIterator<Uint8List> iterator,
+) async* {
+  try {
+    for (final chunk in chunks) {
+      yield chunk;
+    }
+    while (await iterator.moveNext()) {
+      yield iterator.current;
+    }
+  } finally {
+    await iterator.cancel();
+  }
+}
+
+final class _StatusBodyPreview {
+  const _StatusBodyPreview({required this.response, this.bodyPreview});
+
+  final Response response;
+  final String? bodyPreview;
+}

--- a/lib/src/client/retry.dart
+++ b/lib/src/client/retry.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../core/response.dart';
+import '../pipeline/context.dart';
+import '../pipeline/events.dart';
+
+bool shouldRetryResponse(Request request, Response response, Context context) {
+  final policy = context.retryPolicy;
+  if (policy.maxRetries <= 0 ||
+      !policy.allowsMethod(request) ||
+      request.body?.replayable == false) {
+    return false;
+  }
+  return policy.shouldRetryResponse(response);
+}
+
+bool shouldRetryError(Request request, Object error, Context context) {
+  final policy = context.retryPolicy;
+  if (policy.maxRetries <= 0 ||
+      !policy.allowsMethod(request) ||
+      request.body?.replayable == false) {
+    return false;
+  }
+  if (error is CancelError || error is DecodeError) {
+    return false;
+  }
+  if (error is TimeoutError) {
+    return error.retryable;
+  }
+  if (error is NetworkError) {
+    return error.retryable;
+  }
+  return false;
+}
+
+Future<void> beforeRetry(
+  Request request,
+  Context context,
+  Object? error,
+  Response? response,
+  Duration delay,
+) async {
+  emitEvent(
+    context.onEvent,
+    RequestEventType.retryScheduled,
+    request: request,
+    attempt: context.attempt,
+    response: response,
+    error: error,
+    detail: delay.toString(),
+  );
+  await context.clientOptions.hooks
+      .merge(context.requestOptions.hooks)
+      .onRetry
+      ?.call(request, error, response, delay, context);
+}
+
+Future<void> waitRetryDelay(Duration delay, Context context) {
+  final signal = context.signal;
+  if (signal == null) {
+    return Future<void>.delayed(delay);
+  }
+  if (signal.aborted) {
+    throw CancelError(reason: signal.reason);
+  }
+
+  final completer = Completer<void>();
+  final timer = Timer(delay, () {
+    if (!completer.isCompleted) {
+      completer.complete();
+    }
+  });
+  signal.onAbort(() {
+    timer.cancel();
+    if (!completer.isCompleted) {
+      completer.completeError(CancelError(reason: signal.reason));
+    }
+  });
+  return completer.future;
+}

--- a/lib/src/client/timeouts.dart
+++ b/lib/src/client/timeouts.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import '../core/abort.dart';
+import '../core/body.dart';
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../core/response.dart';
+import '../pipeline/context.dart';
+import '../policies.dart';
+
+AbortSignal linkedSignal(AbortSignal? parent) {
+  final signal = AbortSignal();
+  if (parent == null) {
+    return signal;
+  }
+
+  if (parent.aborted) {
+    signal.abort(parent.reason);
+  } else {
+    parent.onAbort(() {
+      signal.abort(parent.reason);
+    });
+  }
+  return signal;
+}
+
+bool needsInternalSignal(TimeoutPolicy policy) {
+  return policy.total != null ||
+      policy.send != null ||
+      policy.firstByte != null ||
+      policy.read != null;
+}
+
+Response withResponseTimeouts(
+  Response response,
+  Request request,
+  Context context,
+) {
+  return withTotalTimeout(
+    withReadTimeout(response, request, context),
+    request,
+    context,
+  );
+}
+
+Response withReadTimeout(Response response, Request request, Context context) {
+  final timeout = context.timeoutPolicy.read;
+  final body = response.body;
+  if (timeout == null || body == null || body.replayable) {
+    return response;
+  }
+
+  return response.copyWith(
+    body: ResponseBody.stream(
+      _readTimeoutStream(body.open(), timeout, request),
+      contentLength: body.contentLength,
+    ),
+  );
+}
+
+Response withTotalTimeout(Response response, Request request, Context context) {
+  final timeout = context.timeoutPolicy.total;
+  final body = response.body;
+  if (timeout == null || body == null || body.replayable) {
+    return response;
+  }
+
+  final deadline = context.createdAt.add(timeout);
+  return response.copyWith(
+    body: ResponseBody.stream(
+      _totalTimeoutStream(
+        body.open(),
+        timeout,
+        deadline,
+        request,
+        context.signal,
+      ),
+      contentLength: body.contentLength,
+    ),
+  );
+}
+
+Stream<List<int>> _readTimeoutStream(
+  Stream<List<int>> source,
+  Duration timeout,
+  Request request,
+) async* {
+  final iterator = StreamIterator<List<int>>(source);
+  try {
+    while (true) {
+      final hasNext = await iterator.moveNext().timeout(
+        timeout,
+        onTimeout: () {
+          final timeoutError = TimeoutError(
+            phase: TimeoutPhase.read,
+            duration: timeout,
+            request: request,
+            sent: true,
+          );
+          throw timeoutError;
+        },
+      );
+      if (!hasNext) {
+        break;
+      }
+      yield iterator.current;
+    }
+  } finally {
+    await iterator.cancel();
+  }
+}
+
+Stream<List<int>> _totalTimeoutStream(
+  Stream<List<int>> source,
+  Duration timeout,
+  DateTime deadline,
+  Request request,
+  AbortSignal? signal,
+) async* {
+  final iterator = StreamIterator<List<int>>(source);
+  try {
+    while (true) {
+      final remaining = deadline.difference(DateTime.now().toUtc());
+      if (remaining <= Duration.zero) {
+        throw _abortTotalTimeout(timeout, request, signal);
+      }
+
+      final hasNext = await iterator.moveNext().timeout(
+        remaining,
+        onTimeout: () {
+          throw _abortTotalTimeout(timeout, request, signal);
+        },
+      );
+      if (!hasNext) {
+        break;
+      }
+      yield iterator.current;
+    }
+  } finally {
+    await iterator.cancel();
+  }
+}
+
+TimeoutError _abortTotalTimeout(
+  Duration timeout,
+  Request request,
+  AbortSignal? signal,
+) {
+  final timeoutError = TimeoutError(
+    phase: TimeoutPhase.total,
+    duration: timeout,
+    request: request,
+    sent: true,
+  );
+  signal?.abort(timeoutError);
+  return timeoutError;
+}

--- a/lib/src/pipeline/runner.dart
+++ b/lib/src/pipeline/runner.dart
@@ -1,0 +1,91 @@
+import '../core/errors.dart';
+import '../core/request.dart';
+import '../core/response.dart';
+import 'context.dart';
+import 'events.dart';
+import 'middleware.dart';
+
+List<Middleware> combineMiddleware(
+  List<Middleware> first,
+  List<Middleware> second,
+) {
+  if (first.isEmpty && second.isEmpty) {
+    return const <Middleware>[];
+  }
+  return <Middleware>[...first, ...second];
+}
+
+Next buildMiddlewarePipeline(List<Middleware> middleware, Next terminal) {
+  Next runner = terminal;
+
+  for (var i = middleware.length - 1; i >= 0; i--) {
+    final current = middleware[i];
+    final next = runner;
+    runner = (request, context) async {
+      final middlewareName = current.runtimeType.toString();
+      Future<Response> guardedNext(Request request, Context context) async {
+        try {
+          return await next(request, context);
+        } catch (error, trace) {
+          if (error is RequestError) {
+            Error.throwWithStackTrace(error, trace);
+          }
+          throw _DownstreamError(error, trace);
+        }
+      }
+
+      void emitMiddlewareEnd({Response? response, Object? error}) {
+        emitEvent(
+          context.onEvent,
+          RequestEventType.middlewareEnd,
+          request: request,
+          attempt: context.attempt,
+          response: response,
+          error: error,
+          detail: middlewareName,
+        );
+      }
+
+      emitEvent(
+        context.onEvent,
+        RequestEventType.middlewareStart,
+        request: request,
+        attempt: context.attempt,
+        detail: middlewareName,
+      );
+      late Response response;
+      try {
+        response = await current.intercept(request, context, guardedNext);
+      } catch (error, trace) {
+        if (error is _DownstreamError) {
+          emitMiddlewareEnd(error: error.error);
+          Error.throwWithStackTrace(error.error, error.trace);
+        }
+        if (error is RequestError) {
+          emitMiddlewareEnd(error: error);
+          rethrow;
+        }
+        final middlewareError = MiddlewareError(
+          middleware: middlewareName,
+          message: 'Middleware execution failed.',
+          request: request,
+          cause: error,
+          trace: trace,
+        );
+        emitMiddlewareEnd(error: middlewareError);
+        throw middlewareError;
+      }
+      emitMiddlewareEnd(response: response);
+      return response;
+    };
+  }
+
+  return runner;
+}
+
+final class _DownstreamError {
+  const _DownstreamError(this.error, this.trace);
+
+  final Object error;
+  final StackTrace trace;
+}


### PR DESCRIPTION
Closes #41

## Summary
- split request preparation, middleware runner, response policy, redirect, retry, timeout, and error normalization out of Client
- keep Client focused on public helpers, send orchestration, operation loop, and transport dispatch
- preserve public API and behavior while avoiding empty middleware list allocation in no-middleware requests

## Validation
- dart analyze
- dart test
- dart test -p chrome
- dart pub publish --dry-run
