### PR TITLE
refactor!: redesign middleware lifecycle capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@
 
 - Removed middleware presets; compose middleware explicitly from the built-in
   middleware types instead.
+- Redesigned middleware around lifecycle capabilities. `Middleware.intercept`
+  and `Next` were replaced by request, attempt, final response, error, and
+  finally capability interfaces.
+- Deprecated `ClientOptions.networkMiddleware` and
+  `RequestOptions.networkMiddleware`; configure common middleware through the
+  primary `middleware` list instead.
 
 ### Added
 
 - Added public API Dartdoc, a cookbook, and checked examples for reusable API
   clients, policies, no-throw flows, middleware, testing, and body
   replayability.
+- `CookieMiddleware` now works across redirects and retries from the primary
+  `middleware` list.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Choose Oxy when you want:
   timeout, network, decode, body, retry, cancel, and middleware failures.
 - Safe retry behavior: replayable request bodies can be retried, one-shot
   streams are never retried implicitly.
-- Middleware with clear scope: application middleware runs once per logical
-  request; network middleware runs for every transport attempt.
+- Middleware with lifecycle capabilities for request transforms, cache
+  resolution, per-attempt handling, and final response processing.
 - `MockTransport` tests that exercise the real Oxy pipeline without opening a
   socket or running a server.
 
@@ -183,8 +183,8 @@ final response = await client.get(
 );
 ```
 
-Application middleware runs once for the logical request. Network middleware
-runs once for every network attempt, including retries and redirects:
+Middleware is configured as one list. Each middleware declares the lifecycle
+capabilities it needs, and Oxy schedules those capabilities at the right phase:
 
 ```dart
 final client = Client(
@@ -192,10 +192,10 @@ final client = Client(
     middleware: [
       RequestIdMiddleware(),
       AuthMiddleware.staticToken('secret'),
+      CookieMiddleware(MemoryCookieJar()),
       CacheMiddleware(),
       LoggingMiddleware(),
     ],
-    networkMiddleware: [CookieMiddleware(MemoryCookieJar())],
   ),
 );
 ```

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -85,10 +85,9 @@ rethrow the captured failure with its original stack trace.
 
 ## Compose Middleware
 
-Application middleware runs once for the logical request. Network middleware
-runs for every network attempt. Most application clients should start with
-application middleware and only use network middleware when they need
-attempt-level behavior.
+Configure middleware as one list. Each middleware declares the lifecycle
+capabilities it needs, and Oxy schedules those capabilities at the request,
+attempt, or final response phase.
 
 See [`example/middleware_stack.dart`](../example/middleware_stack.dart).
 
@@ -98,18 +97,34 @@ final client = Client(
     middleware: [
       RequestIdMiddleware(),
       AuthMiddleware.staticToken('secret'),
+      CookieMiddleware(MemoryCookieJar()),
       CacheMiddleware(),
       LoggingMiddleware(),
     ],
-    networkMiddleware: [CookieMiddleware(MemoryCookieJar())],
   ),
 );
 ```
 
-`CookieMiddleware` belongs in network middleware so redirects and retries can
-store cookies between attempts. It is for native and test transports. Browser
-requests already use browser cookie handling, so the middleware is a no-op on
-Web.
+`CookieMiddleware` works from the main middleware list and stores cookies across
+redirects and retries. It is for native and test transports. Browser requests
+already use browser cookie handling, so the middleware is a no-op on Web.
+
+Custom middleware implements the capabilities it needs:
+
+```dart
+final class TraceMiddleware
+    implements RequestTransformer, FinalResponseHandler {
+  @override
+  Request onRequest(Request request, Context context) {
+    return request.withHeader('x-trace-id', 'trace-1');
+  }
+
+  @override
+  Response onResponse(Request request, Response response, Context context) {
+    return response;
+  }
+}
+```
 
 ## Test with MockTransport
 

--- a/example/middleware_stack.dart
+++ b/example/middleware_stack.dart
@@ -9,6 +9,7 @@ Future<void> main() async {
       middleware: [
         RequestIdMiddleware(requestIdProvider: (_, _) => 'request-1'),
         AuthMiddleware.staticToken('secret'),
+        CookieMiddleware(MemoryCookieJar()),
         CacheMiddleware(
           keyBuilder: (request, context) {
             return '${request.method} ${request.uri}';
@@ -16,7 +17,6 @@ Future<void> main() async {
         ),
         LoggingMiddleware(printer: logs.add),
       ],
-      networkMiddleware: [CookieMiddleware(MemoryCookieJar())],
       transport: MockTransport((request, context) async {
         return Response.json(
           {'ok': true},

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -66,9 +66,9 @@ final class Client {
   /// Creates a new client with [next] as its options.
   Client withOptions(ClientOptions next) => Client(next);
 
-  /// Creates a new client with additional application [middleware].
+  /// Creates a new client with additional lifecycle [middleware].
   ///
-  /// When [replace] is `true`, [middleware] replaces the existing application
+  /// When [replace] is `true`, [middleware] replaces the existing lifecycle
   /// middleware list instead of being appended to it.
   Client withMiddleware(List<Middleware> middleware, {bool replace = false}) {
     return Client(
@@ -139,6 +139,21 @@ final class Client {
     }
     final hooks = this.options.hooks.merge(context.requestOptions.hooks);
     var lifecycleClosed = false;
+    final requestMiddleware = combineMiddleware(
+      this.options.middleware,
+      context.requestOptions.middleware,
+    );
+    final middleware = MiddlewareLifecycle(requestMiddleware);
+    final attemptMiddleware = MiddlewareLifecycle(
+      combineMiddleware(
+        requestMiddleware,
+        combineMiddleware(
+          this.options.networkMiddleware,
+          context.requestOptions.networkMiddleware,
+        ),
+      ),
+    );
+    var lifecycleRequest = prepared;
 
     Future<void> closeLifecycle({Object? error}) async {
       if (lifecycleClosed) {
@@ -146,12 +161,15 @@ final class Client {
       }
       lifecycleClosed = true;
       if (error == null) {
+        await middleware.onFinally(lifecycleRequest, context);
         await hooks.onFinally?.call(prepared, context);
         return;
       }
       try {
+        await middleware.onError(lifecycleRequest, error, context);
         await hooks.onError?.call(prepared, error, context);
       } finally {
+        await middleware.onFinally(lifecycleRequest, context);
         await hooks.onFinally?.call(prepared, context);
       }
     }
@@ -183,26 +201,46 @@ final class Client {
       try {
         await hooks.onRequest?.call(prepared, context);
         throwIfLifecycleClosed();
-        final pipelineResult = await _runApplicationPipeline(prepared, context);
-        var response = pipelineResult.response;
+        lifecycleRequest = await middleware.onRequest(
+          lifecycleRequest,
+          context,
+        );
         throwIfLifecycleClosed();
-        if (!pipelineResult.reachedTerminal) {
+        var response = await middleware.resolve(lifecycleRequest, context);
+        if (response == null) {
+          response = await _runApplicationPipeline(
+            lifecycleRequest,
+            context,
+            attemptMiddleware,
+          );
+        } else {
           response = await _completeShortCircuitedResponse(
-            prepared,
+            lifecycleRequest,
             response,
             context,
+            attemptMiddleware,
           );
         }
         throwIfLifecycleClosed();
         final policyResponse = await applyResponsePolicies(
-          prepared,
+          lifecycleRequest,
           response,
           context,
         );
         throwIfLifecycleClosed();
+        final middlewareResponse = await middleware.onResponse(
+          lifecycleRequest,
+          policyResponse,
+          context,
+        );
+        throwIfLifecycleClosed();
         final nextResponse =
-            await hooks.onResponse?.call(prepared, policyResponse, context) ??
-            policyResponse;
+            await hooks.onResponse?.call(
+              prepared,
+              middlewareResponse,
+              context,
+            ) ??
+            middlewareResponse;
         throwIfLifecycleClosed();
         emitEvent(
           context.onEvent,
@@ -504,53 +542,47 @@ final class Client {
     return response.decode<T>(decoder: decoder);
   }
 
-  Future<_ApplicationPipelineResult> _runApplicationPipeline(
+  Future<Response> _runApplicationPipeline(
     Request request,
     Context context,
-  ) async {
-    final middleware = combineMiddleware(
-      options.middleware,
-      context.requestOptions.middleware,
-    );
-
-    var reachedTerminal = false;
-    final next = buildMiddlewarePipeline(middleware, (
-      nextRequest,
-      nextContext,
-    ) {
-      reachedTerminal = true;
-      if (usesClientRedirects(nextContext)) {
-        return runRedirects(nextRequest, nextContext, (
+    MiddlewareLifecycle attemptMiddleware,
+  ) {
+    if (usesClientRedirects(context)) {
+      return runRedirects(request, context, (redirectRequest, redirectContext) {
+        return _runOperation(
           redirectRequest,
           redirectContext,
-        ) {
-          return _runOperation(redirectRequest, redirectContext);
-        });
-      }
-      return _runOperation(nextRequest, nextContext);
-    });
-    final response = await next(request, context);
-    return _ApplicationPipelineResult(
-      response: response,
-      reachedTerminal: reachedTerminal,
-    );
+          attemptMiddleware,
+        );
+      });
+    }
+    return _runOperation(request, context, attemptMiddleware);
   }
 
   Future<Response> _completeShortCircuitedResponse(
     Request request,
     Response response,
     Context context,
+    MiddlewareLifecycle attemptMiddleware,
   ) {
     if (context.redirectPolicy.mode == RedirectMode.follow &&
         isRedirectStatus(response.status)) {
       return runRedirects(request, context, (redirectRequest, redirectContext) {
-        return _runOperation(redirectRequest, redirectContext);
+        return _runOperation(
+          redirectRequest,
+          redirectContext,
+          attemptMiddleware,
+        );
       }, firstResponse: response);
     }
     return Future.value(withResponseTimeouts(response, request, context));
   }
 
-  Future<Response> _runOperation(Request request, Context context) async {
+  Future<Response> _runOperation(
+    Request request,
+    Context context,
+    MiddlewareLifecycle attemptLifecycle,
+  ) async {
     final retryPolicy = context.retryPolicy;
     Object? lastError;
     Response? lastResponse;
@@ -561,7 +593,7 @@ final class Client {
         attempt: attempt,
         signal: attemptSignal,
       );
-      final attemptRequest = sanitizeRedirectHeaders(request);
+      var attemptRequest = sanitizeRedirectHeaders(request);
 
       if (attempt > 0 && request.body != null && !request.body!.replayable) {
         attemptContext.emit(
@@ -586,12 +618,21 @@ final class Client {
           attempt: attempt,
         );
 
-        var response = await _runNetworkPipeline(
+        attemptRequest = await attemptLifecycle.onAttempt(
           attemptRequest,
+          attemptContext,
+        );
+        var response = await _transport.send(
+          sanitizeRedirectHeaders(attemptRequest),
           attemptContext,
         );
         response = withReadTimeout(response, attemptRequest, attemptContext);
         response = withTotalTimeout(response, attemptRequest, attemptContext);
+        response = await attemptLifecycle.onAttemptResponse(
+          attemptRequest,
+          response,
+          attemptContext,
+        );
 
         emitEvent(
           attemptContext.onEvent,
@@ -686,36 +727,11 @@ final class Client {
     }
   }
 
-  Future<Response> _runNetworkPipeline(Request request, Context context) {
-    final middleware = combineMiddleware(
-      options.networkMiddleware,
-      context.requestOptions.networkMiddleware,
-    );
-
-    final operation = buildMiddlewarePipeline(middleware, (
-      nextRequest,
-      nextContext,
-    ) {
-      return _transport.send(sanitizeRedirectHeaders(nextRequest), nextContext);
-    })(request, context);
-    return operation;
-  }
-
   void _throwIfAborted(AbortSignal? signal, Request request) {
     if (signal?.aborted == true) {
       throw CancelError(reason: signal?.reason, request: request);
     }
   }
-}
-
-final class _ApplicationPipelineResult {
-  const _ApplicationPipelineResult({
-    required this.response,
-    required this.reachedTerminal,
-  });
-
-  final Response response;
-  final bool reachedTerminal;
 }
 
 /// The shared client used by [fetch] and [fetchResult].

--- a/lib/src/client/redirects.dart
+++ b/lib/src/client/redirects.dart
@@ -3,9 +3,11 @@ import '../core/request.dart';
 import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/internal_attributes.dart';
-import '../pipeline/middleware.dart';
 import '../policies.dart';
 import 'response_policies.dart';
+
+typedef RedirectHandler =
+    Future<Response> Function(Request request, Context context);
 
 bool usesClientRedirects(Context context) {
   return context.redirectPolicy.mode == RedirectMode.follow &&
@@ -15,7 +17,7 @@ bool usesClientRedirects(Context context) {
 Future<Response> runRedirects(
   Request request,
   Context context,
-  Next next, {
+  RedirectHandler next, {
   Response? firstResponse,
 }) async {
   var current = request;

--- a/lib/src/features/auth.dart
+++ b/lib/src/features/auth.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import '../core/request.dart';
-import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 
@@ -10,7 +9,7 @@ typedef AuthTokenProvider =
     FutureOr<String?> Function(Request request, Context context);
 
 /// Adds an authorization header when a token is available.
-final class AuthMiddleware implements Middleware {
+final class AuthMiddleware implements RequestTransformer {
   AuthMiddleware({
     required this.tokenProvider,
     this.scheme = 'Bearer',
@@ -44,24 +43,20 @@ final class AuthMiddleware implements Middleware {
   final bool overrideExisting;
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
+  Future<Request> onRequest(Request request, Context context) async {
     if (!overrideExisting && request.headers.has(headerName)) {
-      return next(request, context);
+      return request;
     }
 
     final token = await tokenProvider(request, context);
     if (token == null || token.trim().isEmpty) {
-      return next(request, context);
+      return request;
     }
 
     final value = scheme == null || scheme!.isEmpty
         ? token.trim()
         : '${scheme!} ${token.trim()}';
 
-    return next(request.withHeader(headerName, value), context);
+    return request.withHeader(headerName, value);
   }
 }

--- a/lib/src/features/cache.dart
+++ b/lib/src/features/cache.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import '../core/attributes.dart';
 import '../core/body.dart';
 import '../core/errors.dart';
 import '../core/headers.dart';
@@ -8,10 +9,13 @@ import '../core/request.dart';
 import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
-import '../policies.dart';
 
 /// Builds a cache key for a request.
 typedef CacheKeyBuilder = String Function(Request request, Context context);
+
+const AttributeKey<_CacheState> _cacheStateAttribute = AttributeKey(
+  'oxy.cache.state',
+);
 
 /// A response stored by [CacheStore].
 final class CachedResponse {
@@ -120,7 +124,12 @@ final class MemoryCacheStore implements CacheStore {
 ///
 /// The middleware stores bounded, replayable responses and revalidates cached
 /// entries with ETag or Last-Modified validators when needed.
-final class CacheMiddleware implements Middleware {
+final class CacheMiddleware
+    implements
+        RequestTransformer,
+        RequestResolver,
+        AttemptResponseHandler,
+        FinalResponseHandler {
   CacheMiddleware({
     CacheStore? store,
     this.keyBuilder = _defaultCacheKeyBuilder,
@@ -139,89 +148,122 @@ final class CacheMiddleware implements Middleware {
   final Set<String> _methods;
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
+  Future<Request> onRequest(Request request, Context context) async {
     if (!_methods.contains(request.method.toUpperCase())) {
-      return next(request, context);
+      return request;
     }
 
     final requestControl = _parseCacheControl(request.headers);
     if (requestControl.noStore) {
-      return next(request, context);
+      return request;
     }
 
     final key = keyBuilder(request, context);
     final cached = await _store.read(key);
     final now = DateTime.now().toUtc();
-    if (cached != null &&
-        cached.isFresh(now) &&
-        cached._satisfiesRequest(requestControl, now) &&
-        !requestControl.requiresRevalidation &&
-        !_hasConditionalHeader(request.headers)) {
-      return _validateCachedResponse(
-        request,
-        context,
-        _cloneCached(cached.response),
-      );
+    final revalidationRequest = _revalidationRequest(request, cached);
+    return revalidationRequest.copyWith(
+      attributes: revalidationRequest.attributes.set(
+        _cacheStateAttribute,
+        _CacheState(
+          key: key,
+          cached: cached,
+          canUseFresh:
+              cached != null &&
+              cached.isFresh(now) &&
+              cached._satisfiesRequest(requestControl, now) &&
+              !requestControl.requiresRevalidation &&
+              !_hasConditionalHeader(request.headers),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Response? resolve(Request request, Context context) {
+    final state = request.attributes.get(_cacheStateAttribute);
+    final cached = state?.cached;
+    if (state == null || cached == null || !state.canUseFresh) {
+      return null;
+    }
+    return _cloneCached(cached.response);
+  }
+
+  @override
+  Future<Response> onAttemptResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) async {
+    final state = request.attributes.get(_cacheStateAttribute);
+    final cached = state?.cached;
+    if (state == null || cached == null || response.status != 304) {
+      return response;
     }
 
-    final revalidationRequest = _revalidationRequest(request, cached);
-    final response = await next(
-      revalidationRequest,
-      cached == null ? context : _allowNotModified(context),
-    );
-    final receivedAt = DateTime.now().toUtc();
-    if (response.status == 304 && cached != null) {
-      if (!_notModifiedMatchesCached(request, cached, response)) {
-        return response;
-      }
-      final merged = _mergeNotModified(cached.response, response);
-      final mergedControl = _parseCacheControl(merged.headers);
-      if (mergedControl.noStore ||
-          _hasVaryStar(merged.headers) ||
-          !_cacheableStatus(merged.status)) {
-        await _store.delete(key);
-        return _validateCachedResponse(request, context, _cloneCached(merged));
-      }
-      await _store.write(
-        key,
-        CachedResponse(
-          response: merged,
-          storedAt: receivedAt,
-          expiresAt: _expiresAt(merged, receivedAt),
-          etag: merged.headers.get('etag') ?? cached.etag,
-        ),
-      );
-      return _validateCachedResponse(request, context, _cloneCached(merged));
+    if (!_notModifiedMatchesCached(request, cached, response)) {
+      return response;
     }
+
+    final receivedAt = DateTime.now().toUtc();
+    final merged = _mergeNotModified(cached.response, response);
+    final mergedControl = _parseCacheControl(merged.headers);
+    if (mergedControl.noStore ||
+        _hasVaryStar(merged.headers) ||
+        !_cacheableStatus(merged.status)) {
+      await _store.delete(state.key);
+      return _cloneCached(merged);
+    }
+
+    await _store.write(
+      state.key,
+      CachedResponse(
+        response: merged,
+        storedAt: receivedAt,
+        expiresAt: _expiresAt(merged, receivedAt),
+        etag: merged.headers.get('etag') ?? cached.etag,
+      ),
+    );
+    return _cloneCached(merged);
+  }
+
+  @override
+  Future<Response> onResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) async {
+    final state = request.attributes.get(_cacheStateAttribute);
+    if (state == null || response.fromCache || response.status == 304) {
+      return response;
+    }
+
+    final receivedAt = DateTime.now().toUtc();
 
     final cacheControl = _parseCacheControl(response.headers);
     if (cacheControl.noStore ||
         _hasVaryStar(response.headers) ||
         !_cacheableStatus(response.status)) {
-      await _store.delete(key);
+      await _store.delete(state.key);
       return response;
     }
 
     final expiresAt = _expiresAt(response, receivedAt);
     final etag = response.headers.get('etag');
     if (expiresAt == null && etag == null) {
-      await _store.delete(key);
+      await _store.delete(state.key);
       return response;
     }
 
     final bufferResult = await _tryBuffer(request, response);
     final cacheResponse = bufferResult.cacheResponse;
     if (cacheResponse == null) {
-      await _store.delete(key);
+      await _store.delete(state.key);
       return bufferResult.response;
     }
 
     await _store.write(
-      key,
+      state.key,
       CachedResponse(
         response: cacheResponse,
         storedAt: receivedAt,
@@ -243,17 +285,6 @@ final class CacheMiddleware implements Middleware {
     }
     return '${request.method.toUpperCase()} ${request.url}\n'
         '${headerParts.join('\n')}';
-  }
-
-  Context _allowNotModified(Context context) {
-    return context.copyWith(
-      statusPolicy: StatusPolicy(
-        accept: (response) {
-          return response.status == 304 ||
-              context.statusPolicy.accepts(response);
-        },
-      ),
-    );
   }
 
   Request _revalidationRequest(Request request, CachedResponse? cached) {
@@ -354,25 +385,6 @@ final class CacheMiddleware implements Middleware {
     );
   }
 
-  Response _validateCachedResponse(
-    Request request,
-    Context context,
-    Response response,
-  ) {
-    if (context.redirectPolicy.mode == RedirectMode.error &&
-        _isRedirectStatus(response.status)) {
-      throw StatusError(
-        response,
-        request: request,
-        message: 'Redirect blocked by RedirectPolicy.error.',
-      );
-    }
-    if (!context.statusPolicy.accepts(response)) {
-      throw StatusError(response, request: request);
-    }
-    return response;
-  }
-
   Response _mergeNotModified(Response cached, Response notModified) {
     final headers = Headers(cached.headers);
     for (final name in notModified.headers.keys()) {
@@ -412,13 +424,6 @@ final class CacheMiddleware implements Middleware {
 
   bool _cacheableStatus(int status) {
     return const <int>{200, 203, 204, 206, 300, 301, 308}.contains(status);
-  }
-
-  bool _isRedirectStatus(int status) {
-    return switch (status) {
-      301 || 302 || 303 || 307 || 308 => true,
-      _ => false,
-    };
   }
 
   _CacheControl _parseCacheControl(Headers headers) {
@@ -537,6 +542,18 @@ final class _CacheBufferResult {
 
   final Response response;
   final Response? cacheResponse;
+}
+
+final class _CacheState {
+  const _CacheState({
+    required this.key,
+    required this.cached,
+    required this.canUseFresh,
+  });
+
+  final String key;
+  final CachedResponse? cached;
+  final bool canUseFresh;
 }
 
 const Set<String> _cacheKeyIgnoredHeaders = <String>{

--- a/lib/src/features/cookie_middleware.dart
+++ b/lib/src/features/cookie_middleware.dart
@@ -1,4 +1,3 @@
-import '../core/errors.dart';
 import '../core/request.dart';
 import '../core/response.dart';
 import '../pipeline/context.dart';
@@ -10,34 +9,32 @@ import 'cookie.dart';
 ///
 /// Browser requests already use the browser's cookie handling, so this
 /// middleware is a no-op on Web transports.
-final class CookieMiddleware implements Middleware {
+final class CookieMiddleware
+    implements AttemptTransformer, AttemptResponseHandler {
   const CookieMiddleware(this.jar);
 
   /// Cookie storage used by the middleware.
   final CookieJar jar;
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
+  Future<Request> onAttempt(Request request, Context context) {
     if (context.capability.name == 'web') {
-      return next(request, context);
+      return Future.value(request);
     }
 
-    final hydrated = await _attachCookies(request);
-    try {
-      final response = await next(hydrated, context);
-      await _storeResponseCookies(_cookieUri(hydrated, response), response);
-      return response;
-    } on StatusError catch (error) {
-      await _storeResponseCookies(
-        _cookieUri(hydrated, error.statusResponse),
-        error.statusResponse,
-      );
-      rethrow;
+    return _attachCookies(request);
+  }
+
+  @override
+  Future<Response> onAttemptResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) async {
+    if (context.capability.name != 'web') {
+      await _storeResponseCookies(_cookieUri(request, response), response);
     }
+    return response;
   }
 
   Future<Request> _attachCookies(Request request) async {

--- a/lib/src/features/logging.dart
+++ b/lib/src/features/logging.dart
@@ -1,4 +1,5 @@
 import '../core/errors.dart';
+import '../core/attributes.dart';
 import '../core/request.dart';
 import '../core/response.dart';
 import '../pipeline/context.dart';
@@ -10,37 +11,47 @@ typedef LogPrinter = void Function(String message);
 /// Logs request start, response completion, and failures.
 ///
 /// User info, query strings, and fragments are redacted before logging.
-final class LoggingMiddleware implements Middleware {
+final class LoggingMiddleware
+    implements RequestTransformer, FinalResponseHandler, FinalErrorHandler {
   LoggingMiddleware({LogPrinter? printer}) : _printer = printer ?? print;
 
   final LogPrinter _printer;
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
+  Request onRequest(Request request, Context context) {
     final stopwatch = Stopwatch()..start();
     _printer('[oxy] -> ${request.method} ${_redact(request.uri)}');
+    return request.copyWith(
+      attributes: request.attributes.set(_loggingStateAttribute, stopwatch),
+    );
+  }
 
-    try {
-      final response = await next(request, context);
-      stopwatch.stop();
-      _printer(
-        '[oxy] <- ${response.status} ${request.method} '
-        '${_redact(request.uri)} (${stopwatch.elapsedMilliseconds}ms)',
-      );
+  @override
+  Response onResponse(Request request, Response response, Context context) {
+    final stopwatch = request.attributes.get(_loggingStateAttribute);
+    if (stopwatch == null) {
       return response;
-    } catch (error) {
-      stopwatch.stop();
-      final label = error is RequestError ? error.runtimeType : 'error';
-      _printer(
-        '[oxy] !! ${request.method} ${_redact(request.uri)} '
-        '(${stopwatch.elapsedMilliseconds}ms) $label',
-      );
-      rethrow;
     }
+    stopwatch.stop();
+    _printer(
+      '[oxy] <- ${response.status} ${request.method} '
+      '${_redact(request.uri)} (${stopwatch.elapsedMilliseconds}ms)',
+    );
+    return response;
+  }
+
+  @override
+  void onError(Request request, Object error, Context context) {
+    final stopwatch = request.attributes.get(_loggingStateAttribute);
+    if (stopwatch == null) {
+      return;
+    }
+    stopwatch.stop();
+    final label = error is RequestError ? error.runtimeType : 'error';
+    _printer(
+      '[oxy] !! ${request.method} ${_redact(request.uri)} '
+      '(${stopwatch.elapsedMilliseconds}ms) $label',
+    );
   }
 
   String _redact(Uri uri) {
@@ -57,3 +68,5 @@ final class LoggingMiddleware implements Middleware {
     return sanitized.toString();
   }
 }
+
+const _loggingStateAttribute = AttributeKey<Stopwatch>('oxy.logging.state');

--- a/lib/src/features/request_id.dart
+++ b/lib/src/features/request_id.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import '../core/request.dart';
-import '../core/response.dart';
 import '../pipeline/context.dart';
 import '../pipeline/middleware.dart';
 
@@ -11,7 +10,7 @@ typedef RequestIdProvider =
     FutureOr<String?> Function(Request request, Context context);
 
 /// Adds a request ID header when one is available.
-final class RequestIdMiddleware implements Middleware {
+final class RequestIdMiddleware implements RequestTransformer {
   RequestIdMiddleware({
     RequestIdProvider? requestIdProvider,
     this.headerName = 'x-request-id',
@@ -29,21 +28,17 @@ final class RequestIdMiddleware implements Middleware {
   static final Random _random = Random();
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
+  Future<Request> onRequest(Request request, Context context) async {
     if (!overrideExisting && request.headers.has(headerName)) {
-      return next(request, context);
+      return request;
     }
 
     final requestId = await _requestIdProvider(request, context);
     if (requestId == null || requestId.trim().isEmpty) {
-      return next(request, context);
+      return request;
     }
 
-    return next(request.withHeader(headerName, requestId.trim()), context);
+    return request.withHeader(headerName, requestId.trim());
   }
 
   static String _defaultRequestId(Request _, Context _) {

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -53,6 +53,10 @@ final class ClientOptions {
     this.redirectPolicy = RedirectPolicy.follow,
     this.statusPolicy = StatusPolicy.throwOnError,
     this.middleware = const <Middleware>[],
+    @Deprecated(
+      'Use middleware with lifecycle-capable middleware instead. '
+      'networkMiddleware will be removed before 1.0.',
+    )
     this.networkMiddleware = const <Middleware>[],
     this.hooks = const Hooks(),
     this.transport,
@@ -81,10 +85,14 @@ final class ClientOptions {
   /// Status validation policy applied to every response by default.
   final StatusPolicy statusPolicy;
 
-  /// Middleware that runs once for each logical request.
+  /// Middleware scheduled by lifecycle capabilities.
   final List<Middleware> middleware;
 
-  /// Middleware that runs for each network attempt.
+  /// Deprecated attempt-only middleware.
+  @Deprecated(
+    'Use middleware with lifecycle-capable middleware instead. '
+    'networkMiddleware will be removed before 1.0.',
+  )
   final List<Middleware> networkMiddleware;
 
   /// Lifecycle hooks applied to every request.
@@ -117,6 +125,10 @@ final class ClientOptions {
     RedirectPolicy? redirectPolicy,
     StatusPolicy? statusPolicy,
     List<Middleware>? middleware,
+    @Deprecated(
+      'Use middleware with lifecycle-capable middleware instead. '
+      'networkMiddleware will be removed before 1.0.',
+    )
     List<Middleware>? networkMiddleware,
     Hooks? hooks,
     Transport? transport,
@@ -159,6 +171,10 @@ final class RequestOptions {
     this.redirectPolicy,
     this.statusPolicy,
     this.middleware = const <Middleware>[],
+    @Deprecated(
+      'Use middleware with lifecycle-capable middleware instead. '
+      'networkMiddleware will be removed before 1.0.',
+    )
     this.networkMiddleware = const <Middleware>[],
     this.hooks,
     this.signal,
@@ -185,10 +201,14 @@ final class RequestOptions {
   /// Status validation policy override.
   final StatusPolicy? statusPolicy;
 
-  /// Application middleware added to this request.
+  /// Lifecycle middleware added to this request.
   final List<Middleware> middleware;
 
-  /// Network middleware added to this request.
+  /// Deprecated attempt-only middleware added to this request.
+  @Deprecated(
+    'Use middleware with lifecycle-capable middleware instead. '
+    'networkMiddleware will be removed before 1.0.',
+  )
   final List<Middleware> networkMiddleware;
 
   /// Lifecycle hook overrides.
@@ -215,6 +235,10 @@ final class RequestOptions {
     RedirectPolicy? redirectPolicy,
     StatusPolicy? statusPolicy,
     List<Middleware>? middleware,
+    @Deprecated(
+      'Use middleware with lifecycle-capable middleware instead. '
+      'networkMiddleware will be removed before 1.0.',
+    )
     List<Middleware>? networkMiddleware,
     Hooks? hooks,
     AbortSignal? signal,

--- a/lib/src/pipeline/middleware.dart
+++ b/lib/src/pipeline/middleware.dart
@@ -4,16 +4,62 @@ import '../core/request.dart';
 import '../core/response.dart';
 import 'context.dart';
 
-/// Continues request processing from middleware.
-typedef Next = Future<Response> Function(Request request, Context context);
-
-/// Intercepts a request before or around the next pipeline step.
+/// Marker interface for middleware lifecycle capabilities.
 ///
-/// Application middleware runs once per logical request. Network middleware
-/// runs once per network attempt, including retries and redirects.
-abstract interface class Middleware {
-  /// Handles [request] and either returns a [Response] or calls [next].
-  Future<Response> intercept(Request request, Context context, Next next);
+/// Implement one or more capability interfaces to participate in the request
+/// lifecycle. Oxy schedules each capability at the phase where it belongs.
+abstract interface class Middleware {}
+
+/// Mutates or observes the logical request before cache resolution or network
+/// attempts begin.
+abstract interface class RequestTransformer implements Middleware {
+  /// Returns the request that should continue through the pipeline.
+  FutureOr<Request> onRequest(Request request, Context context);
+}
+
+/// Resolves a logical request without reaching the transport.
+abstract interface class RequestResolver implements Middleware {
+  /// Returns a response to short-circuit the request, or `null` to continue.
+  FutureOr<Response?> resolve(Request request, Context context);
+}
+
+/// Mutates or observes a single transport attempt.
+abstract interface class AttemptTransformer implements Middleware {
+  /// Returns the request that should be sent for this attempt.
+  FutureOr<Request> onAttempt(Request request, Context context);
+}
+
+/// Handles the raw response from a single transport attempt before retry,
+/// redirect, and final status policies run.
+abstract interface class AttemptResponseHandler implements Middleware {
+  /// Returns the response that should continue attempt processing.
+  FutureOr<Response> onAttemptResponse(
+    Request request,
+    Response response,
+    Context context,
+  );
+}
+
+/// Handles the final successful response for a logical request.
+abstract interface class FinalResponseHandler implements Middleware {
+  /// Returns the response that should be delivered to hooks and callers.
+  FutureOr<Response> onResponse(
+    Request request,
+    Response response,
+    Context context,
+  );
+}
+
+/// Observes a final failure for a logical request.
+abstract interface class FinalErrorHandler implements Middleware {
+  /// Called before client error hooks when request processing fails.
+  FutureOr<void> onError(Request request, Object error, Context context);
+}
+
+/// Observes the end of a logical request.
+abstract interface class FinalFinallyHandler implements Middleware {
+  /// Called once request processing has finished.
+  FutureOr<void> onFinally(Request request, Context context);
 }
 
 /// Hook called with a request and context.
@@ -52,7 +98,7 @@ final class Hooks {
     this.onFinally,
   });
 
-  /// Called before application middleware.
+  /// Called before lifecycle middleware.
   final HookCallback? onRequest;
 
   /// Called after response policies and before the final response is returned.

--- a/lib/src/pipeline/runner.dart
+++ b/lib/src/pipeline/runner.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../core/errors.dart';
 import '../core/request.dart';
 import '../core/response.dart';
@@ -15,77 +17,195 @@ List<Middleware> combineMiddleware(
   return <Middleware>[...first, ...second];
 }
 
-Next buildMiddlewarePipeline(List<Middleware> middleware, Next terminal) {
-  Next runner = terminal;
+final class MiddlewareLifecycle {
+  MiddlewareLifecycle(List<Middleware> middleware)
+    : _middleware = List<Middleware>.unmodifiable(middleware);
 
-  for (var i = middleware.length - 1; i >= 0; i--) {
-    final current = middleware[i];
-    final next = runner;
-    runner = (request, context) async {
-      final middlewareName = current.runtimeType.toString();
-      Future<Response> guardedNext(Request request, Context context) async {
-        try {
-          return await next(request, context);
-        } catch (error, trace) {
-          if (error is RequestError) {
-            Error.throwWithStackTrace(error, trace);
-          }
-          throw _DownstreamError(error, trace);
+  final List<Middleware> _middleware;
+
+  bool get isEmpty => _middleware.isEmpty;
+
+  Future<Request> onRequest(Request request, Context context) async {
+    var current = request;
+    for (final middleware in _middleware) {
+      if (middleware is RequestTransformer) {
+        current = await _runCapability<Request>(
+          middleware,
+          'onRequest',
+          current,
+          context,
+          () => middleware.onRequest(current, context),
+        );
+      }
+    }
+    return current;
+  }
+
+  Future<Response?> resolve(Request request, Context context) async {
+    for (final middleware in _middleware) {
+      if (middleware is RequestResolver) {
+        final response = await _runCapability<Response?>(
+          middleware,
+          'resolve',
+          request,
+          context,
+          () => middleware.resolve(request, context),
+        );
+        if (response != null) {
+          return response;
         }
       }
+    }
+    return null;
+  }
 
-      void emitMiddlewareEnd({Response? response, Object? error}) {
+  Future<Request> onAttempt(Request request, Context context) async {
+    var current = request;
+    for (final middleware in _middleware) {
+      if (middleware is AttemptTransformer) {
+        current = await _runCapability<Request>(
+          middleware,
+          'onAttempt',
+          current,
+          context,
+          () => middleware.onAttempt(current, context),
+        );
+      }
+    }
+    return current;
+  }
+
+  Future<Response> onAttemptResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) async {
+    var current = response;
+    for (var i = _middleware.length - 1; i >= 0; i--) {
+      final middleware = _middleware[i];
+      if (middleware is AttemptResponseHandler) {
+        current = await _runCapability<Response>(
+          middleware,
+          'onAttemptResponse',
+          request,
+          context,
+          () => middleware.onAttemptResponse(request, current, context),
+          response: current,
+        );
+      }
+    }
+    return current;
+  }
+
+  Future<Response> onResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) async {
+    var current = response;
+    for (var i = _middleware.length - 1; i >= 0; i--) {
+      final middleware = _middleware[i];
+      if (middleware is FinalResponseHandler) {
+        current = await _runCapability<Response>(
+          middleware,
+          'onResponse',
+          request,
+          context,
+          () => middleware.onResponse(request, current, context),
+          response: current,
+        );
+      }
+    }
+    return current;
+  }
+
+  Future<void> onError(Request request, Object error, Context context) async {
+    for (var i = _middleware.length - 1; i >= 0; i--) {
+      final middleware = _middleware[i];
+      if (middleware is FinalErrorHandler) {
+        await _runCapability<void>(
+          middleware,
+          'onError',
+          request,
+          context,
+          () => middleware.onError(request, error, context),
+        );
+      }
+    }
+  }
+
+  Future<void> onFinally(Request request, Context context) async {
+    for (var i = _middleware.length - 1; i >= 0; i--) {
+      final middleware = _middleware[i];
+      if (middleware is FinalFinallyHandler) {
+        await _runCapability<void>(
+          middleware,
+          'onFinally',
+          request,
+          context,
+          () => middleware.onFinally(request, context),
+        );
+      }
+    }
+  }
+
+  Future<T> _runCapability<T>(
+    Middleware middleware,
+    String capability,
+    Request request,
+    Context context,
+    FutureOr<T> Function() run, {
+    Response? response,
+  }) async {
+    final detail = '${middleware.runtimeType}.$capability';
+    emitEvent(
+      context.onEvent,
+      RequestEventType.middlewareStart,
+      request: request,
+      attempt: context.attempt,
+      detail: detail,
+    );
+
+    try {
+      final result = await run();
+      emitEvent(
+        context.onEvent,
+        RequestEventType.middlewareEnd,
+        request: request,
+        attempt: context.attempt,
+        response: result is Response ? result : response,
+        detail: detail,
+      );
+      return result;
+    } catch (error, trace) {
+      if (error is RequestError) {
         emitEvent(
           context.onEvent,
           RequestEventType.middlewareEnd,
           request: request,
           attempt: context.attempt,
-          response: response,
           error: error,
-          detail: middlewareName,
+          detail: detail,
         );
+        rethrow;
       }
 
+      final middlewareError = MiddlewareError(
+        middleware: detail,
+        message: 'Middleware execution failed.',
+        request: request,
+        cause: error,
+        trace: trace,
+      );
       emitEvent(
         context.onEvent,
-        RequestEventType.middlewareStart,
+        RequestEventType.middlewareEnd,
         request: request,
         attempt: context.attempt,
-        detail: middlewareName,
+        error: middlewareError,
+        detail: detail,
       );
-      late Response response;
-      try {
-        response = await current.intercept(request, context, guardedNext);
-      } catch (error, trace) {
-        if (error is _DownstreamError) {
-          emitMiddlewareEnd(error: error.error);
-          Error.throwWithStackTrace(error.error, error.trace);
-        }
-        if (error is RequestError) {
-          emitMiddlewareEnd(error: error);
-          rethrow;
-        }
-        final middlewareError = MiddlewareError(
-          middleware: middlewareName,
-          message: 'Middleware execution failed.',
-          request: request,
-          cause: error,
-          trace: trace,
-        );
-        emitMiddlewareEnd(error: middlewareError);
-        throw middlewareError;
-      }
-      emitMiddlewareEnd(response: response);
-      return response;
-    };
+      throw middlewareError;
+    }
   }
-
-  return runner;
-}
-
-final class _DownstreamError {
-  const _DownstreamError(this.error, this.trace);
-
-  final Object error;
-  final StackTrace trace;
 }

--- a/test/features_test.dart
+++ b/test/features_test.dart
@@ -189,7 +189,7 @@ void main() {
     late Request finalRequest;
     final client = Client(
       ClientOptions(
-        networkMiddleware: [CookieMiddleware(jar)],
+        middleware: [CookieMiddleware(jar)],
         transport: MockTransport((request, context) async {
           calls += 1;
           if (calls == 1) {
@@ -231,7 +231,7 @@ void main() {
       late Request redirected;
       final client = Client(
         ClientOptions(
-          networkMiddleware: [CookieMiddleware(jar)],
+          middleware: [CookieMiddleware(jar)],
           transport: MockTransport((request, context) async {
             calls += 1;
             if (calls == 1) {

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -21,47 +21,53 @@ final class CapabilityTransport implements Transport {
   }
 }
 
-final class HeaderMiddleware implements Middleware {
-  HeaderMiddleware(this.name, this.value, this.events);
+final class RequestHeaderMiddleware implements RequestTransformer {
+  RequestHeaderMiddleware(this.name, this.value, this.events);
 
   final String name;
   final String value;
   final List<String> events;
 
   @override
-  Future<Response> intercept(Request request, Context context, Next next) {
+  Request onRequest(Request request, Context context) {
     events.add('$name:${context.attempt}');
-    return next(request.withHeader(name, value), context);
+    return request.withHeader(name, value);
   }
 }
 
-final class PassThroughMiddleware implements Middleware {
+final class AttemptHeaderMiddleware implements AttemptTransformer {
+  AttemptHeaderMiddleware(this.name, this.value, this.events);
+
+  final String name;
+  final String value;
+  final List<String> events;
+
+  @override
+  Request onAttempt(Request request, Context context) {
+    events.add('$name:${context.attempt}');
+    return request.withHeader(name, value);
+  }
+}
+
+final class PassThroughMiddleware implements RequestTransformer {
   const PassThroughMiddleware();
 
   @override
-  Future<Response> intercept(Request request, Context context, Next next) {
-    return next(request, context);
-  }
+  Request onRequest(Request request, Context context) => request;
 }
 
-final class ShortCircuitMiddleware implements Middleware {
+final class ShortCircuitMiddleware implements RequestResolver {
   const ShortCircuitMiddleware(this.response);
 
   final Response response;
 
   @override
-  Future<Response> intercept(
-    Request request,
-    Context context,
-    Next next,
-  ) async {
-    return response;
-  }
+  Response resolve(Request request, Context context) => response;
 }
 
 void main() {
   test(
-    'runs application middleware once and network middleware per attempt',
+    'schedules request middleware once and attempt middleware per attempt',
     () async {
       var calls = 0;
       final events = <String>[];
@@ -81,8 +87,10 @@ void main() {
         ClientOptions(
           baseUrl: Uri.parse('https://example.com'),
           transport: transport,
-          middleware: [HeaderMiddleware('x-app', '1', events)],
-          networkMiddleware: [HeaderMiddleware('x-net', '1', events)],
+          middleware: [
+            RequestHeaderMiddleware('x-app', '1', events),
+            AttemptHeaderMiddleware('x-net', '1', events),
+          ],
         ),
       );
 
@@ -189,7 +197,9 @@ void main() {
       ClientOptions(
         onEvent: events.add,
         middleware: const [PassThroughMiddleware()],
-        networkMiddleware: [HeaderMiddleware('x-net', '1', headerEvents)],
+        networkMiddleware: [
+          AttemptHeaderMiddleware('x-net', '1', headerEvents),
+        ],
         transport: MockTransport((request, context) async {
           return Response.text('ok');
         }),
@@ -207,10 +217,10 @@ void main() {
         .map((event) => '${event.type.name}:${event.detail}:${event.attempt}')
         .toList();
     expect(middlewareEvents, [
-      'middlewareStart:PassThroughMiddleware:0',
-      'middlewareStart:HeaderMiddleware:0',
-      'middlewareEnd:HeaderMiddleware:0',
-      'middlewareEnd:PassThroughMiddleware:0',
+      'middlewareStart:PassThroughMiddleware.onRequest:0',
+      'middlewareEnd:PassThroughMiddleware.onRequest:0',
+      'middlewareStart:AttemptHeaderMiddleware.onAttempt:0',
+      'middlewareEnd:AttemptHeaderMiddleware.onAttempt:0',
     ]);
   });
 
@@ -402,13 +412,13 @@ void main() {
     expect(calls, 2);
   });
 
-  test('client redirect loop does not rerun application middleware', () async {
+  test('client redirect loop does not rerun request middleware', () async {
     var calls = 0;
     final events = <String>[];
     final client = Client(
       ClientOptions(
         baseUrl: Uri.parse('https://example.com'),
-        middleware: [HeaderMiddleware('x-app', '1', events)],
+        middleware: [RequestHeaderMiddleware('x-app', '1', events)],
         transport: MockTransport((request, context) async {
           calls += 1;
           if (calls == 1) {
@@ -587,16 +597,16 @@ void main() {
   );
 
   test(
-    'cross-origin redirects strip auth without rerunning app middleware',
+    'cross-origin redirects strip auth without rerunning request middleware',
     () async {
       var calls = 0;
       late Request redirected;
       final events = <String>[];
       final client = Client(
         ClientOptions(
-          middleware: [AuthMiddleware.staticToken('secret')],
-          networkMiddleware: [
-            HeaderMiddleware('authorization', 'Bearer network', events),
+          middleware: [
+            AuthMiddleware.staticToken('secret'),
+            AttemptHeaderMiddleware('authorization', 'Bearer network', events),
           ],
           transport: MockTransport((request, context) async {
             calls += 1;


### PR DESCRIPTION
## Summary

- replace the `Middleware.intercept`/`Next` API with lifecycle capability interfaces
- schedule request and attempt capabilities from the primary `middleware` list while keeping `networkMiddleware` as a deprecated attempt-only migration bridge
- migrate built-in auth, request-id, cookie, cache, and logging middleware to the lifecycle model
- update tests, README, cookbook, example, and changelog for the new single-list middleware model

## Validation

- `dart analyze`
- `dart test`
- `dart test -p node`
- `dart test -p chrome test/client_browser_test.dart`
- `dart pub publish --dry-run`

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Middleware API redesigned; existing implementations require updates to new lifecycle-based model.
  * `networkMiddleware` configuration fields deprecated; consolidate into primary `middleware` list.

* **New Features**
  * CookieMiddleware now persists cookies across redirects and retries when configured via middleware list.

* **Documentation**
  * Updated CHANGELOG, README, and cookbook with new middleware patterns and lifecycle documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->