### PR TITLE
refactor: use http_parser for Retry-After dates

### DIFF
--- a/lib/src/policies.dart
+++ b/lib/src/policies.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:http_parser/http_parser.dart' show parseHttpDate;
+
 import 'core/request.dart';
 import 'core/response.dart';
 
@@ -156,7 +158,7 @@ final class RetryPolicy {
       return Duration(seconds: max(0, seconds));
     }
 
-    final date = _parseHttpDate(value.trim()) ?? DateTime.tryParse(value);
+    final date = _parseRetryAfterDate(value.trim());
     if (date == null) {
       return null;
     }
@@ -165,45 +167,14 @@ final class RetryPolicy {
     return delta.isNegative ? Duration.zero : delta;
   }
 
-  DateTime? _parseHttpDate(String value) {
-    final match = RegExp(
-      r'^[A-Za-z]{3}, (\d{2}) ([A-Za-z]{3}) (\d{4}) '
-      r'(\d{2}):(\d{2}):(\d{2}) GMT$',
-    ).firstMatch(value);
-    if (match == null) {
-      return null;
+  DateTime? _parseRetryAfterDate(String value) {
+    try {
+      return parseHttpDate(value);
+    } on FormatException {
+      return DateTime.tryParse(value);
     }
-
-    final month = _httpMonths[match.group(2)!.toLowerCase()];
-    if (month == null) {
-      return null;
-    }
-
-    return DateTime.utc(
-      int.parse(match.group(3)!),
-      month,
-      int.parse(match.group(1)!),
-      int.parse(match.group(4)!),
-      int.parse(match.group(5)!),
-      int.parse(match.group(6)!),
-    );
   }
 }
-
-const Map<String, int> _httpMonths = <String, int>{
-  'jan': 1,
-  'feb': 2,
-  'mar': 3,
-  'apr': 4,
-  'may': 5,
-  'jun': 6,
-  'jul': 7,
-  'aug': 8,
-  'sep': 9,
-  'oct': 10,
-  'nov': 11,
-  'dec': 12,
-};
 
 /// Redirect handling behavior.
 enum RedirectMode {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ environment:
 
 dependencies:
   ht: ^0.3.1
+  http_parser: ^4.1.2
   ocookie: ^0.2.0
 
 dev_dependencies:

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -66,7 +66,10 @@ void main() {
       expect(body.contentType, startsWith('multipart/form-data; boundary='));
       expect(body.contentLength, greaterThan(0));
 
+      final boundary = body.contentType!.split('boundary=').last;
       final text = utf8.decode(await body.bytes());
+      expect(text, startsWith('--$boundary\r\n'));
+      expect(text, endsWith('--$boundary--\r\n'));
       expect(text, contains('name="name"'));
       expect(text, contains('oxy'));
       expect(text, contains('filename="a.txt"'));

--- a/test/policy_test.dart
+++ b/test/policy_test.dart
@@ -413,6 +413,33 @@ void main() {
     expect(delay, greaterThan(const Duration(days: 1)));
   });
 
+  test('retry policy ignores invalid Retry-After dates', () {
+    final response = Response.text(
+      'busy',
+      status: 503,
+      headers: {'retry-after': 'Wed, 99 Nope 2099 07:28:00 GMT'},
+    );
+
+    final delay = const RetryPolicy(
+      baseDelay: Duration(milliseconds: 100),
+      jitterRatio: 0,
+    ).delayFor(0, response: response);
+
+    expect(delay, const Duration(milliseconds: 100));
+  });
+
+  test('retry policy accepts obsolete HTTP-date Retry-After values', () {
+    final response = Response.text(
+      'busy',
+      status: 503,
+      headers: {'retry-after': 'Wednesday, 21-Oct-99 07:28:00 GMT'},
+    );
+
+    final delay = const RetryPolicy().delayFor(0, response: response);
+
+    expect(delay, Duration.zero);
+  });
+
   test('retry policy rejects negative delay configuration', () {
     expect(
       () =>


### PR DESCRIPTION
## Summary

- Promote `http_parser` to a direct dependency and use its `parseHttpDate` helper for `Retry-After` HTTP-date parsing.
- Remove Oxy's local HTTP-date regex/month-table parser while preserving ISO `DateTime.tryParse` fallback for non-HTTP date strings.
- Add regression coverage for invalid `Retry-After` date fallback, obsolete HTTP-date parsing, and multipart body boundary/header consistency.

## Notes

I evaluated switching `Body.fromFormData` to `ht.FormData.encodeMultipart()` without an explicit boundary, but `ht` currently generates that boundary with `Random.secure()`, which fails under the Node test platform. This PR keeps Oxy's explicit boundary generation for cross-platform compatibility and documents the finding through the passing Node suite.

Closes #55

## Validation

- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart test -p node`
- `dart test -p chrome test/client_browser_test.dart`