### PR TITLE
refactor: rely on ht multipart boundary generation

### DIFF
--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:ht/ht.dart' as ht;
@@ -20,9 +19,6 @@ typedef BodyStreamFactory = Stream<List<int>> Function();
 /// replayable stream factories are replayable. Bodies created from a raw
 /// `Stream<List<int>>` are one-shot.
 final class Body {
-  static final Random _boundaryRandom = Random();
-  static int _boundaryCounter = 0;
-
   Body._({
     required this.kind,
     required this.replayable,
@@ -146,7 +142,7 @@ final class Body {
 
   /// Creates a replayable multipart form body.
   static Body fromFormData(ht.FormData formData) {
-    final encoded = formData.encodeMultipart(boundary: _multipartBoundary());
+    final encoded = formData.encodeMultipart();
     return Body._(
       kind: BodyKind.multipart,
       replayable: true,
@@ -186,13 +182,6 @@ final class Body {
       replayable: true,
       open: () => body.clone(),
     );
-  }
-
-  static String _multipartBoundary() {
-    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
-    final counter = (_boundaryCounter++).toRadixString(16);
-    final random = _boundaryRandom.nextInt(0x3fffffff).toRadixString(16);
-    return '----oxy-$timestamp-$counter-$random';
   }
 
   /// Opens the body stream.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  ht: ^0.3.1
+  ht: ^0.3.2
   http_parser: ^4.1.2
   ocookie: ^0.2.0
 


### PR DESCRIPTION
## Summary

- Bump `ht` to `^0.3.2`, which includes the JS-safe multipart boundary fix from `medz/ht#15`.
- Let `Body.fromFormData` call `formData.encodeMultipart()` directly.
- Remove Oxy's local multipart boundary generator and `dart:math` dependency from body conversion.

Closes #60

## Validation

- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart test -p node`
- `dart test -p chrome test/client_browser_test.dart`