### PR TITLE
refactor: prefer blob body sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Changed
+
+- Upgraded to `ht ^0.4.0`.
+- Removed `ht.Body` as an accepted Oxy body source; use stable data
+  containers such as `Blob` instead.
+
 ## 0.4.0
 
 ### Breaking Changes

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -134,6 +134,11 @@ final class Body {
       ht.FormData() => Body.fromFormData(value),
       ht.URLSearchParams() => Body.fromUrlSearchParams(value),
       ht.Blob() => Body.fromBlob(value),
+      ht.Body() => throw ArgumentError.value(
+        value,
+        'value',
+        'Unsupported body input.',
+      ),
       Stream<List<int>>() => Body.stream(value),
       _ => throw ArgumentError.value(value, 'value', 'Unsupported body input.'),
     };

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -134,7 +134,6 @@ final class Body {
       ht.FormData() => Body.fromFormData(value),
       ht.URLSearchParams() => Body.fromUrlSearchParams(value),
       ht.Blob() => Body.fromBlob(value),
-      ht.Body() => Body.fromHtBody(value),
       Stream<List<int>>() => Body.stream(value),
       _ => throw ArgumentError.value(value, 'value', 'Unsupported body input.'),
     };
@@ -172,15 +171,6 @@ final class Body {
       contentLength: blob.size,
       contentType: blob.type.isEmpty ? null : blob.type,
       open: () => blob.stream(),
-    );
-  }
-
-  /// Creates a replayable body from an `ht` body clone factory.
-  static Body fromHtBody(ht.Body body) {
-    return Body._(
-      kind: BodyKind.stream,
-      replayable: true,
-      open: () => body.clone(),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  ht: ^0.3.2
+  ht: ^0.4.0
   http_parser: ^4.1.2
   ocookie: ^0.2.0
 

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
 import 'package:oxy/src/transport/transport.stub.dart' as stub;
 import 'package:test/test.dart';
@@ -95,6 +96,10 @@ void main() {
       expect(body.contentType, contains('application/x-www-form-urlencoded'));
       expect(await body.text(), 'q=oxy&page=1');
       expect(await body.text(), 'q=oxy&page=1');
+    });
+
+    test('rejects ht Body before generic stream coercion', () {
+      expect(() => Body.from(ht.Body('hello')), throwsArgumentError);
     });
   });
 


### PR DESCRIPTION
## Summary

- Upgrade `ht` to `^0.4.0`.
- Remove `ht.Body` as an accepted Oxy body source.
- Keep Oxy body coercion focused on stable data containers such as `Blob`.

Closes #56

## Validation

- `dart pub get`
- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `dart test -p node`
- `dart test -p chrome test/client_browser_test.dart`