### PR TITLE
refactor!: remove network middleware options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   parameters.
 - Removed Oxy's `MemoryCookieJar`, `parseSetCookie`, and cookie request-matching
   extension APIs in favor of upstream `ocookie` primitives.
+- Removed deprecated `ClientOptions.networkMiddleware` and
+  `RequestOptions.networkMiddleware`; pass attempt middleware through
+  `middleware` instead.
 
 ### Changed
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -144,15 +144,7 @@ final class Client {
       context.requestOptions.middleware,
     );
     final middleware = MiddlewareLifecycle(requestMiddleware);
-    final attemptMiddleware = MiddlewareLifecycle(
-      combineMiddleware(
-        requestMiddleware,
-        combineMiddleware(
-          this.options.networkMiddleware,
-          context.requestOptions.networkMiddleware,
-        ),
-      ),
-    );
+    final attemptMiddleware = middleware;
     var lifecycleRequest = prepared;
 
     Future<void> closeLifecycle({Object? error}) async {

--- a/lib/src/client/request_resolution.dart
+++ b/lib/src/client/request_resolution.dart
@@ -128,10 +128,6 @@ RequestOptions _mergeRequestOptions(
       ...requestOptions.middleware,
       ...sendOptions.middleware,
     ],
-    networkMiddleware: <Middleware>[
-      ...requestOptions.networkMiddleware,
-      ...sendOptions.networkMiddleware,
-    ],
     hooks: requestOptions.hooks?.merge(sendOptions.hooks) ?? sendOptions.hooks,
     signal: sendOptions.signal,
     onSendProgress: sendOptions.onSendProgress,

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -53,11 +53,6 @@ final class ClientOptions {
     this.redirectPolicy = RedirectPolicy.follow,
     this.statusPolicy = StatusPolicy.throwOnError,
     this.middleware = const <Middleware>[],
-    @Deprecated(
-      'Use middleware with lifecycle-capable middleware instead. '
-      'networkMiddleware will be removed before 1.0.',
-    )
-    this.networkMiddleware = const <Middleware>[],
     this.hooks = const Hooks(),
     this.transport,
     this.keepAlive = true,
@@ -87,13 +82,6 @@ final class ClientOptions {
 
   /// Middleware scheduled by lifecycle capabilities.
   final List<Middleware> middleware;
-
-  /// Deprecated attempt-only middleware.
-  @Deprecated(
-    'Use middleware with lifecycle-capable middleware instead. '
-    'networkMiddleware will be removed before 1.0.',
-  )
-  final List<Middleware> networkMiddleware;
 
   /// Lifecycle hooks applied to every request.
   final Hooks hooks;
@@ -125,11 +113,6 @@ final class ClientOptions {
     RedirectPolicy? redirectPolicy,
     StatusPolicy? statusPolicy,
     List<Middleware>? middleware,
-    @Deprecated(
-      'Use middleware with lifecycle-capable middleware instead. '
-      'networkMiddleware will be removed before 1.0.',
-    )
-    List<Middleware>? networkMiddleware,
     Hooks? hooks,
     Transport? transport,
     bool? keepAlive,
@@ -146,7 +129,6 @@ final class ClientOptions {
       redirectPolicy: redirectPolicy ?? this.redirectPolicy,
       statusPolicy: statusPolicy ?? this.statusPolicy,
       middleware: middleware ?? this.middleware,
-      networkMiddleware: networkMiddleware ?? this.networkMiddleware,
       hooks: hooks ?? this.hooks,
       transport: transport ?? this.transport,
       keepAlive: keepAlive ?? this.keepAlive,
@@ -171,11 +153,6 @@ final class RequestOptions {
     this.redirectPolicy,
     this.statusPolicy,
     this.middleware = const <Middleware>[],
-    @Deprecated(
-      'Use middleware with lifecycle-capable middleware instead. '
-      'networkMiddleware will be removed before 1.0.',
-    )
-    this.networkMiddleware = const <Middleware>[],
     this.hooks,
     this.signal,
     this.onSendProgress,
@@ -204,13 +181,6 @@ final class RequestOptions {
   /// Lifecycle middleware added to this request.
   final List<Middleware> middleware;
 
-  /// Deprecated attempt-only middleware added to this request.
-  @Deprecated(
-    'Use middleware with lifecycle-capable middleware instead. '
-    'networkMiddleware will be removed before 1.0.',
-  )
-  final List<Middleware> networkMiddleware;
-
   /// Lifecycle hook overrides.
   final Hooks? hooks;
 
@@ -235,11 +205,6 @@ final class RequestOptions {
     RedirectPolicy? redirectPolicy,
     StatusPolicy? statusPolicy,
     List<Middleware>? middleware,
-    @Deprecated(
-      'Use middleware with lifecycle-capable middleware instead. '
-      'networkMiddleware will be removed before 1.0.',
-    )
-    List<Middleware>? networkMiddleware,
     Hooks? hooks,
     AbortSignal? signal,
     ProgressCallback? onSendProgress,
@@ -254,7 +219,6 @@ final class RequestOptions {
       redirectPolicy: redirectPolicy ?? this.redirectPolicy,
       statusPolicy: statusPolicy ?? this.statusPolicy,
       middleware: middleware ?? this.middleware,
-      networkMiddleware: networkMiddleware ?? this.networkMiddleware,
       hooks: hooks ?? this.hooks,
       signal: signal ?? this.signal,
       onSendProgress: onSendProgress ?? this.onSendProgress,

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -196,8 +196,8 @@ void main() {
     final client = Client(
       ClientOptions(
         onEvent: events.add,
-        middleware: const [PassThroughMiddleware()],
-        networkMiddleware: [
+        middleware: [
+          const PassThroughMiddleware(),
           AttemptHeaderMiddleware('x-net', '1', headerEvents),
         ],
         transport: MockTransport((request, context) async {


### PR DESCRIPTION
## Summary

- Remove the deprecated `ClientOptions.networkMiddleware` and `RequestOptions.networkMiddleware` API surface.
- Route all lifecycle scheduling through the primary `middleware` list.
- Update pipeline coverage to use attempt-capable middleware from `middleware` instead of the deprecated attempt-only list.

## Impact

This is a breaking API cleanup. Users should pass attempt middleware through `middleware`; implemented capability interfaces determine which lifecycle phases each middleware participates in.

Closes #67

## Validation

- `dart format --set-exit-if-changed lib test`
- `git diff --check`
- `dart analyze`
- `dart test`
- `dart test -p node`
- `dart test -p chrome test/client_browser_test.dart`