### PR TITLE
fix: patch http_parser RFC850 date parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
+      - run: dart run patchwork apply
+      - run: dart run patchwork doctor
       - run: dart analyze
       - run: dart test -p vm
       - run: dart test -p node
       - run: dart test -p chrome
+      - run: dart run patchwork undo http_parser
       - run: dart pub publish --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.patchwork/
 .dart_tool/
+pubspec_overrides.yaml
 
 pubspec.lock

--- a/patches/http_parser@4.1.2.patch
+++ b/patches/http_parser@4.1.2.patch
@@ -1,33 +1,51 @@
 diff --git a/lib/src/http_date.dart b/lib/src/http_date.dart
-index 0cedd9a6d88b8ac5b3f9289acf406af640679b99..f67b269449303d5cf0786cfe5f696f7a349af1eb 100644
+index 0cedd9a6d88b8ac5b3f9289acf406af640679b99..0af2f27924616e96273d725cee71369745653730 100644
 --- a/lib/src/http_date.dart
 +++ b/lib/src/http_date.dart
-@@ -68,7 +68,7 @@ DateTime parseHttpDate(String date) =>
+@@ -68,13 +68,13 @@ DateTime parseHttpDate(String date) =>
          scanner.expect('-');
          final month = _parseMonth(scanner);
          scanner.expect('-');
 -        final year = 1900 + _parseInt(scanner, 2);
-+        final year = _parseRfc850Year(scanner);
++        final twoDigitYear = _parseInt(scanner, 2);
          scanner.expect(' ');
          final time = _parseTime(scanner);
          scanner.expect(' GMT');
-@@ -126,6 +126,21 @@ int _parseInt(StringScanner scanner, int digits) {
+         scanner.expectDone();
+ 
+-        return _makeDateTime(year, month, day, time);
++        return _makeRfc850DateTime(twoDigitYear, month, day, time);
+       }
+ 
+       // RFC 1123 and asctime both start with a short weekday.
+@@ -126,6 +126,32 @@ int _parseInt(StringScanner scanner, int digits) {
    return int.parse(scanner.lastMatch![0]!);
  }
  
-+/// Parses an obsolete RFC 850 two-digit year.
++/// Returns a UTC [DateTime] from an obsolete RFC 850 two-digit year.
 +///
 +/// Per RFC 9110, timestamps that appear more than 50 years in the future are
 +/// interpreted as the most recent past year with the same last two digits.
-+int _parseRfc850Year(StringScanner scanner) {
-+  final twoDigitYear = _parseInt(scanner, 2);
++DateTime _makeRfc850DateTime(
++    int twoDigitYear, int month, int day, DateTime time) {
 +  final now = DateTime.now().toUtc();
 +  final currentCentury = now.year - (now.year % 100);
-+  var year = currentCentury + twoDigitYear;
-+  if (year - now.year > 50) {
-+    year -= 100;
++  final year = currentCentury + twoDigitYear;
++  var dateTime = _makeDateTime(year, month, day, time);
++  final futureLimit = DateTime.utc(
++      now.year + 50,
++      now.month,
++      now.day,
++      now.hour,
++      now.minute,
++      now.second,
++      now.millisecond,
++      now.microsecond);
++
++  if (dateTime.isAfter(futureLimit)) {
++    dateTime = _makeDateTime(year - 100, month, day, time);
 +  }
-+  return year;
++  return dateTime;
 +}
 +
  /// Parses an timestamp of the form "HH:MM:SS" on a 24-hour clock.

--- a/patches/http_parser@4.1.2.patch
+++ b/patches/http_parser@4.1.2.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/src/http_date.dart b/lib/src/http_date.dart
+index 0cedd9a6d88b8ac5b3f9289acf406af640679b99..f67b269449303d5cf0786cfe5f696f7a349af1eb 100644
+--- a/lib/src/http_date.dart
++++ b/lib/src/http_date.dart
+@@ -68,7 +68,7 @@ DateTime parseHttpDate(String date) =>
+         scanner.expect('-');
+         final month = _parseMonth(scanner);
+         scanner.expect('-');
+-        final year = 1900 + _parseInt(scanner, 2);
++        final year = _parseRfc850Year(scanner);
+         scanner.expect(' ');
+         final time = _parseTime(scanner);
+         scanner.expect(' GMT');
+@@ -126,6 +126,21 @@ int _parseInt(StringScanner scanner, int digits) {
+   return int.parse(scanner.lastMatch![0]!);
+ }
+ 
++/// Parses an obsolete RFC 850 two-digit year.
++///
++/// Per RFC 9110, timestamps that appear more than 50 years in the future are
++/// interpreted as the most recent past year with the same last two digits.
++int _parseRfc850Year(StringScanner scanner) {
++  final twoDigitYear = _parseInt(scanner, 2);
++  final now = DateTime.now().toUtc();
++  final currentCentury = now.year - (now.year % 100);
++  var year = currentCentury + twoDigitYear;
++  if (year - now.year > 50) {
++    year -= 100;
++  }
++  return year;
++}
++
+ /// Parses an timestamp of the form "HH:MM:SS" on a 24-hour clock.
+ DateTime _parseTime(StringScanner scanner) {
+   final hours = _parseInt(scanner, 2);

--- a/patchwork.yaml
+++ b/patchwork.yaml
@@ -1,0 +1,8 @@
+overlays:
+  -
+    package: "http_parser"
+    version: "4.1.2"
+    sha256: "e2ca3a27e7bfb319db162622ce3df7b1df565014b701c8e651ec3c89b02dc180"
+    patch: "patches/http_parser@4.1.2.patch"
+    reason: "Fix RFC850 two-digit HTTP-date years used by Retry-After."
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   ht: ^0.4.2
   http_parser: ^4.1.2
   ocookie: ^0.3.0
+  patchwork: ^0.5.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/test/policy_test.dart
+++ b/test/policy_test.dart
@@ -430,6 +430,27 @@ void main() {
     expect(delay, lessThanOrEqualTo(const Duration(minutes: 5)));
   });
 
+  test('retry policy rolls over RFC850 dates more than 50 years ahead', () {
+    final now = DateTime.now().toUtc();
+    final retryAt = DateTime.utc(
+      now.year + 50,
+      now.month,
+      now.day,
+      now.hour,
+      now.minute,
+      now.second,
+    ).add(const Duration(days: 1));
+    final response = Response.text(
+      'busy',
+      status: 503,
+      headers: {'retry-after': _formatRfc850Date(retryAt)},
+    );
+
+    final delay = const RetryPolicy().delayFor(0, response: response);
+
+    expect(delay, Duration.zero);
+  });
+
   test('retry policy ignores invalid Retry-After dates', () {
     final response = Response.text(
       'busy',

--- a/test/policy_test.dart
+++ b/test/policy_test.dart
@@ -413,6 +413,23 @@ void main() {
     expect(delay, greaterThan(const Duration(days: 1)));
   });
 
+  test('retry policy honors RFC850 Retry-After dates in this century', () {
+    final retryAt = DateTime.now().toUtc().add(const Duration(minutes: 5));
+    final response = Response.text(
+      'busy',
+      status: 503,
+      headers: {'retry-after': _formatRfc850Date(retryAt)},
+    );
+
+    final delay = const RetryPolicy(
+      baseDelay: Duration(milliseconds: 100),
+      jitterRatio: 0,
+    ).delayFor(0, response: response);
+
+    expect(delay, greaterThan(Duration.zero));
+    expect(delay, lessThanOrEqualTo(const Duration(minutes: 5)));
+  });
+
   test('retry policy ignores invalid Retry-After dates', () {
     final response = Response.text(
       'busy',
@@ -451,4 +468,41 @@ void main() {
       throwsA(isA<AssertionError>()),
     );
   });
+}
+
+const _longWeekdays = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+const _shortMonths = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+String _formatRfc850Date(DateTime date) {
+  date = date.toUtc();
+  final day = date.day.toString().padLeft(2, '0');
+  final year = (date.year % 100).toString().padLeft(2, '0');
+  final hour = date.hour.toString().padLeft(2, '0');
+  final minute = date.minute.toString().padLeft(2, '0');
+  final second = date.second.toString().padLeft(2, '0');
+  return '${_longWeekdays[date.weekday - 1]}, '
+      '$day-${_shortMonths[date.month - 1]}-$year '
+      '$hour:$minute:$second GMT';
 }


### PR DESCRIPTION
## Summary
- add Patchwork as a provider dependency so Oxy can publish a narrow http_parser overlay
- register an http_parser@4.1.2 overlay that fixes RFC850 two-digit HTTP-date year parsing
- add an Oxy Retry-After regression test and ignore Patchwork generated state

## Validation
- dart run patchwork doctor --setup --explain
- dart run patchwork status
- dart test
- downstream overlay smoke with Oxy as a path dependency

Closes #61