### PR TITLE
chore: upgrade ht to 0.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  ht: ^0.4.2
+  ht: ^0.5.0
   http_parser: ^4.1.2
   ocookie: ^0.3.0
   patchwork: ^0.5.0


### PR DESCRIPTION
## Summary

- Update the direct `ht` dependency constraint from `^0.4.2` to `^0.5.0`.
- Keep the change limited to dependency metadata; Oxy already uses `String` request methods and does not expose `ht.Request` or `ht.Response` as public API.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart run patchwork apply`
- `dart test -p vm -p chrome`

No GitHub issue is linked; this is routine dependency maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library dependency to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->