### PR TITLE
feat: accept ht Body primitives as request bodies

### DIFF
--- a/lib/oxy.dart
+++ b/lib/oxy.dart
@@ -23,7 +23,8 @@
 /// ```
 library;
 
-export 'package:ht/ht.dart' show Blob, FormData, Multipart, URLSearchParams;
+export 'package:ht/ht.dart'
+    show Blob, BlobPart, File, FormData, Multipart, URLSearchParams;
 
 export 'src/client.dart';
 export 'src/core/abort.dart';

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -12,6 +12,8 @@ enum BodyKind { empty, bytes, text, json, form, multipart, file, stream }
 /// Opens a fresh byte stream for a replayable body.
 typedef BodyStreamFactory = Stream<List<int>> Function();
 
+typedef _HtBodyFactory = ht.Body Function();
+
 /// A request body with replayability and metadata.
 ///
 /// Oxy uses [replayable] to decide whether a request can be retried safely.
@@ -22,7 +24,7 @@ final class Body {
   Body._({
     required this.kind,
     required this.replayable,
-    required BodyStreamFactory open,
+    required _HtBodyFactory open,
     this.contentLength,
     this.contentType,
   }) : _open = open;
@@ -38,7 +40,7 @@ final class Body {
 
   /// The content type supplied by the body source, or `null`.
   final String? contentType;
-  final BodyStreamFactory _open;
+  final _HtBodyFactory _open;
   bool _used = false;
 
   /// Creates an empty replayable body.
@@ -53,7 +55,7 @@ final class Body {
       kind: kind,
       replayable: true,
       contentLength: data.length,
-      open: () => Stream<List<int>>.value(Uint8List.fromList(data)),
+      open: () => ht.Body(Uint8List.fromList(data)),
     );
   }
 
@@ -61,7 +63,7 @@ final class Body {
   static Body fromText(
     String value, {
     Encoding encoding = utf8,
-    String contentType = 'text/plain; charset=utf-8',
+    String contentType = 'text/plain;charset=UTF-8',
   }) {
     final data = encoding.encode(value);
     return Body._(
@@ -69,7 +71,7 @@ final class Body {
       replayable: true,
       contentLength: data.length,
       contentType: contentType,
-      open: () => Stream<List<int>>.value(Uint8List.fromList(data)),
+      open: () => ht.Body(Uint8List.fromList(data)),
     );
   }
 
@@ -84,7 +86,7 @@ final class Body {
       replayable: true,
       contentLength: data.length,
       contentType: contentType,
-      open: () => Stream<List<int>>.value(Uint8List.fromList(data)),
+      open: () => ht.Body(Uint8List.fromList(data)),
     );
   }
 
@@ -100,7 +102,7 @@ final class Body {
           throw const BodyStateError('Request body stream was already used.');
         }
         consumed = true;
-        return stream;
+        return ht.Body(stream);
       },
     );
   }
@@ -117,7 +119,7 @@ final class Body {
       replayable: true,
       contentLength: contentLength,
       contentType: contentType,
-      open: open,
+      open: () => ht.Body(open()),
     );
   }
 
@@ -130,18 +132,26 @@ final class Body {
       Body() => value,
       String() => Body.fromText(value),
       Uint8List() => Body.fromBytes(value),
+      ByteBuffer() => Body.fromBytes(value.asUint8List()),
       List<int>() => Body.fromBytes(value),
       ht.FormData() => Body.fromFormData(value),
       ht.URLSearchParams() => Body.fromUrlSearchParams(value),
       ht.Blob() => Body.fromBlob(value),
-      ht.Body() => throw ArgumentError.value(
-        value,
-        'value',
-        'Unsupported body input.',
-      ),
+      ht.Body() => Body._fromHtBody(value),
       Stream<List<int>>() => Body.stream(value),
-      _ => throw ArgumentError.value(value, 'value', 'Unsupported body input.'),
+      _ => Body._fromHtBody(ht.Body(value)),
     };
+  }
+
+  /// Creates a replayable body backed by an upstream [ht.Body].
+  static Body _fromHtBody(ht.Body body) {
+    final source = body.clone();
+    return Body._(
+      kind: BodyKind.stream,
+      replayable: true,
+      contentType: source.contentType,
+      open: () => source.clone(),
+    );
   }
 
   /// Creates a replayable multipart form body.
@@ -152,7 +162,7 @@ final class Body {
       replayable: true,
       contentLength: encoded.contentLength,
       contentType: encoded.contentType,
-      open: () => encoded.stream,
+      open: () => ht.Body(encoded.stream),
     );
   }
 
@@ -163,8 +173,8 @@ final class Body {
       kind: BodyKind.form,
       replayable: true,
       contentLength: data.length,
-      contentType: 'application/x-www-form-urlencoded; charset=utf-8',
-      open: () => Stream<List<int>>.value(Uint8List.fromList(data)),
+      contentType: ht.Body(params).contentType,
+      open: () => ht.Body(Uint8List.fromList(data)),
     );
   }
 
@@ -175,7 +185,7 @@ final class Body {
       replayable: true,
       contentLength: blob.size,
       contentType: blob.type.isEmpty ? null : blob.type,
-      open: () => blob.stream(),
+      open: () => ht.Body(blob),
     );
   }
 
@@ -191,9 +201,7 @@ final class Body {
       _used = true;
     }
 
-    return _open().map((chunk) {
-      return chunk is Uint8List ? chunk : Uint8List.fromList(chunk);
-    });
+    return _open().stream;
   }
 
   /// Reads the body as bytes.

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -40,11 +40,15 @@ void main() {
   group('Body', () {
     test('marks bytes and json bodies as replayable', () async {
       final bytes = Body.fromBytes([1, 2, 3]);
+      final text = Body.from('hello')!;
       final json = Body.fromJson({'ok': true});
 
       expect(bytes.replayable, isTrue);
       expect(await bytes.bytes(), [1, 2, 3]);
       expect(await bytes.bytes(), [1, 2, 3]);
+      expect(text.kind, BodyKind.text);
+      expect(text.contentType, 'text/plain;charset=UTF-8');
+      expect(await text.text(), 'hello');
       expect(json.contentType, contains('application/json'));
       expect(utf8.decode(await json.bytes()), '{"ok":true}');
     });
@@ -94,8 +98,9 @@ void main() {
       expect(utf8.decode(await body.bytes()), text);
     });
 
-    test('treats Blob bodies as streaming file-like bodies', () async {
+    test('treats Blob and File bodies as streaming file-like bodies', () async {
       final body = Body.from(Blob(['hello'], 'text/plain'))!;
+      final fileBody = Body.from(File(['file'], 'a.txt', type: 'text/plain'))!;
 
       expect(body.kind, BodyKind.file);
       expect(body.replayable, isTrue);
@@ -103,6 +108,13 @@ void main() {
       expect(body.contentType, 'text/plain');
       expect(await body.text(), 'hello');
       expect(await body.text(), 'hello');
+
+      expect(fileBody.kind, BodyKind.file);
+      expect(fileBody.replayable, isTrue);
+      expect(fileBody.contentLength, 4);
+      expect(fileBody.contentType, 'text/plain');
+      expect(await fileBody.text(), 'file');
+      expect(await fileBody.text(), 'file');
     });
 
     test('accepts URLSearchParams as replayable form body', () async {
@@ -110,13 +122,49 @@ void main() {
       final body = Body.from(params)!;
 
       expect(body.kind, BodyKind.form);
-      expect(body.contentType, contains('application/x-www-form-urlencoded'));
+      expect(
+        body.contentType,
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
       expect(await body.text(), 'q=oxy&page=1');
       expect(await body.text(), 'q=oxy&page=1');
     });
 
-    test('rejects ht Body before generic stream coercion', () {
-      expect(() => Body.from(ht.Body('hello')), throwsArgumentError);
+    test('accepts ht Body as replayable upstream body', () async {
+      final upstream = ht.Body('hello');
+      final body = Body.from(upstream)!;
+
+      expect(body.kind, BodyKind.stream);
+      expect(body.replayable, isTrue);
+      expect(body.contentLength, isNull);
+      expect(body.contentType, 'text/plain;charset=UTF-8');
+      expect(await body.text(), 'hello');
+      expect(await body.text(), 'hello');
+      expect(upstream.bodyUsed, isFalse);
+    });
+
+    test('accepts stream-backed ht Body through clone semantics', () async {
+      final upstream = ht.Body(
+        Stream<List<int>>.fromIterable([
+          utf8.encode('hello '),
+          utf8.encode('stream'),
+        ]),
+      );
+      final body = Body.from(upstream)!;
+
+      expect(body.replayable, isTrue);
+      expect(await body.text(), 'hello stream');
+      expect(await body.text(), 'hello stream');
+    });
+
+    test('accepts ByteBuffer through ht-compatible body input', () async {
+      final buffer = Uint8List.fromList([1, 2, 3]).buffer;
+      final body = Body.from(buffer)!;
+
+      expect(body.kind, BodyKind.bytes);
+      expect(body.replayable, isTrue);
+      expect(body.contentLength, 3);
+      expect(await body.bytes(), [1, 2, 3]);
     });
   });
 


### PR DESCRIPTION
## Summary

- layer Oxy request body consumption over `ht.Body`
- accept `ht.Body` directly through `Body.from(...)` without consuming the upstream body
- cover ht body primitives including `ByteBuffer`, `File`, `URLSearchParams`, `FormData`, `Blob`, and stream-backed `ht.Body`
- export `File` and `BlobPart` from `package:oxy/oxy.dart`

## Impact

`Body` now acts as Oxy's metadata view over `ht.Body`: Oxy keeps `kind`, `replayable`, `contentLength`, and `contentType`, while byte consumption goes through `ht.Body`. Raw `Stream<List<int>>` remains one-shot to preserve retry and redirect semantics; callers can wrap a stream with `ht.Body(stream)` when they want ht clone semantics.

Fixes #69

## Validation

- `dart format lib/oxy.dart lib/src/core/body.dart test/core_test.dart`
- `dart analyze`
- `dart test -p vm`
- `dart test -p node`
- `dart test -p chrome`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded public API to export `BlobPart` and `File` types for broader usability.

* **Updates**
  * Enhanced body replay and streaming capabilities for improved reliability.
  * Updated default content-type format for text bodies to use `'text/plain;charset=UTF-8'`.

* **Tests**
  * Expanded test coverage for body replayability and various input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->