### PR TITLE
refactor!: align request bodies with ht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### Breaking Changes
+
+- Reworked request `Body` as a direct `ht.Body` subclass. The Oxy-specific
+  `BodyKind`, `Body.from*`, `Body.open()`, and request-body `contentLength`
+  APIs, plus `BodyStreamFactory`, were removed; use the upstream `ht.Body` APIs
+  such as `stream()`, `bytes()`, `text()`, `json()`, `clone()`, `size`, and
+  `contentType`.
+
+### Changed
+
+- Upgraded to `ht ^0.6.0` and accept upstream `ht.Body` values directly as
+  request bodies.
+- Replayable request bodies are cloned for retry and preserved-method redirect
+  attempts so each attempt consumes an independent `ht.Body`.
+
 ## 0.5.0
 
 ### Breaking Changes

--- a/lib/oxy.dart
+++ b/lib/oxy.dart
@@ -29,7 +29,7 @@ export 'package:ht/ht.dart'
 export 'src/client.dart';
 export 'src/core/abort.dart';
 export 'src/core/attributes.dart';
-export 'src/core/body.dart';
+export 'src/core/body.dart' show Body, ResponseBody;
 export 'src/core/errors.dart';
 export 'src/core/headers.dart';
 export 'src/core/request.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -285,7 +285,7 @@ final class Client {
   /// [url] can be a [String] or [Uri]. Relative URLs are resolved against
   /// [ClientOptions.baseUrl]. Pass [json] to encode a JSON request body and set
   /// the content type automatically, or pass [body] for raw body inputs accepted
-  /// by [Body.from].
+  /// by [Body].
   Future<Response> request(
     String method,
     Object url, {
@@ -585,7 +585,7 @@ final class Client {
         attempt: attempt,
         signal: attemptSignal,
       );
-      var attemptRequest = sanitizeRedirectHeaders(request);
+      var attemptRequest = sanitizeRedirectHeaders(_requestForAttempt(request));
 
       if (attempt > 0 && request.body != null && !request.body!.replayable) {
         attemptContext.emit(
@@ -717,6 +717,14 @@ final class Client {
         throw normalized;
       }
     }
+  }
+
+  Request _requestForAttempt(Request request) {
+    final body = request.body;
+    if (body == null || !body.replayable) {
+      return request;
+    }
+    return request.copyWith(body: body.clone());
   }
 
   void _throwIfAborted(AbortSignal? signal, Request request) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -585,7 +585,9 @@ final class Client {
         attempt: attempt,
         signal: attemptSignal,
       );
-      var attemptRequest = sanitizeRedirectHeaders(_requestForAttempt(request));
+      var attemptRequest = sanitizeRedirectHeaders(
+        _requestForAttempt(request, attemptContext),
+      );
 
       if (attempt > 0 && request.body != null && !request.body!.replayable) {
         attemptContext.emit(
@@ -719,12 +721,25 @@ final class Client {
     }
   }
 
-  Request _requestForAttempt(Request request) {
+  Request _requestForAttempt(Request request, Context context) {
     final body = request.body;
-    if (body == null || !body.replayable) {
+    if (body == null ||
+        !body.replayable ||
+        !_mayNeedBodyReplay(request, context)) {
       return request;
     }
     return request.copyWith(body: body.clone());
+  }
+
+  bool _mayNeedBodyReplay(Request request, Context context) {
+    final retryPolicy = context.retryPolicy;
+    if (context.attempt < retryPolicy.maxRetries &&
+        retryPolicy.allowsMethod(request)) {
+      return true;
+    }
+
+    return usesClientRedirects(context) &&
+        context.redirectPolicy.maxRedirects > 0;
   }
 
   void _throwIfAborted(AbortSignal? signal, Request request) {

--- a/lib/src/client/redirects.dart
+++ b/lib/src/client/redirects.dart
@@ -119,11 +119,13 @@ Request _redirectRequest(Request request, Response response, String location) {
     nextHeaders.delete('content-length');
     nextHeaders.delete('content-type');
   }
+  final nextBody = clearBody ? null : request.body?.clone();
 
   return request.copyWith(
     method: method,
     uri: nextUri,
     headers: nextHeaders,
+    body: nextBody,
     clearBody: clearBody,
     attributes: nextAttributes,
   );

--- a/lib/src/client/request_resolution.dart
+++ b/lib/src/client/request_resolution.dart
@@ -67,10 +67,11 @@ ResolvedRequest resolveClientRequest(
   if (body?.contentType != null && !headers.has('content-type')) {
     headers.set('content-type', body!.contentType!);
   }
+  final contentLength = knownBodyLength(body);
   if (capability.name != 'web' &&
-      body?.contentLength != null &&
+      contentLength != null &&
       !headers.has('content-length')) {
-    headers.set('content-length', body!.contentLength!.toString());
+    headers.set('content-length', contentLength.toString());
   }
 
   final prepared = request.copyWith(
@@ -93,9 +94,9 @@ Body? resolveRequestBody({
     throw ArgumentError('Use either body or json, not both.');
   }
   if (!identical(json, jsonOmitted)) {
-    return Body.fromJson(json);
+    return requestJsonBody(json);
   }
-  return Body.from(body);
+  return requestBodyFrom(body);
 }
 
 void _overrideHeaders(Headers target, Headers source) {

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -90,7 +90,11 @@ Body? requestBodyFrom(Object? value) {
 
 /// Creates a JSON request body.
 Body requestJsonBody(Object? value) {
-  return Body(ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'));
+  return Body._withPolicy(
+    ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'),
+    replayable: true,
+    streamUpload: false,
+  );
 }
 
 /// Returns a body byte length when it is available without consuming [body].

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -76,11 +76,7 @@ Body? requestBodyFrom(Object? value) {
 
 /// Creates a JSON request body.
 Body requestJsonBody(Object? value) {
-  return Body._withPolicy(
-    ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'),
-    replayable: true,
-    streamUpload: false,
-  );
+  return Body(ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'));
 }
 
 /// Returns a body byte length when it is available without consuming [body].

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -76,7 +76,11 @@ Body? requestBodyFrom(Object? value) {
 
 /// Creates a JSON request body.
 Body requestJsonBody(Object? value) {
-  return Body(ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'));
+  return Body._withPolicy(
+    ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'),
+    replayable: true,
+    streamUpload: false,
+  );
 }
 
 /// Returns a body byte length when it is available without consuming [body].

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -39,7 +39,7 @@ final class Body extends ht.Body {
       throw const BodyStateError('Body is not replayable.');
     }
     return Body._withPolicy(
-      super.clone(),
+      this,
       replayable: true,
       streamUpload: _streamUpload,
     );
@@ -57,10 +57,25 @@ final class Body extends ht.Body {
   static bool _defaultStreamUpload(Object? init) {
     return switch (init) {
       Body() => init._streamUpload,
-      ht.Body() => true,
+      ht.Body() => _streamsUpstreamBody(init),
       Stream<List<int>>() || ht.FormData() || ht.Blob() => true,
       _ => false,
     };
+  }
+
+  static bool _streamsUpstreamBody(ht.Body body) {
+    if (knownBodyLength(body) == null) {
+      return true;
+    }
+
+    final contentType = body.contentType?.toLowerCase();
+    if (contentType == null ||
+        contentType == 'text/plain;charset=utf-8' ||
+        contentType == 'application/x-www-form-urlencoded;charset=utf-8') {
+      return false;
+    }
+
+    return true;
   }
 }
 

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -57,8 +57,7 @@ final class Body extends ht.Body {
   static bool _defaultStreamUpload(Object? init) {
     return switch (init) {
       Body() => init._streamUpload,
-      ht.Body() =>
-        _isMultipart(init.contentType) || knownBodyLength(init) == null,
+      ht.Body() => true,
       Stream<List<int>>() || ht.FormData() || ht.Blob() => true,
       _ => false,
     };
@@ -94,10 +93,6 @@ int? knownBodyLength(ht.Body? body) {
 /// Whether web transport should upload [body] as a stream.
 bool streamsRequestBody(Body? body) {
   return body?._streamUpload ?? false;
-}
-
-bool _isMultipart(String? contentType) {
-  return contentType?.toLowerCase().startsWith('multipart/form-data') ?? false;
 }
 
 /// A response body with replayability and content length metadata.

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -6,227 +6,98 @@ import 'package:ht/ht.dart' as ht;
 
 import 'errors.dart';
 
-/// The source kind of a request body.
-enum BodyKind { empty, bytes, text, json, form, multipart, file, stream }
-
 /// Opens a fresh byte stream for a replayable body.
-typedef BodyStreamFactory = Stream<List<int>> Function();
+typedef _BodyStreamFactory = Stream<List<int>> Function();
 
-typedef _HtBodyFactory = ht.Body Function();
-
-/// A request body with replayability and metadata.
+/// A request body backed by `ht.Body`.
 ///
 /// Oxy uses [replayable] to decide whether a request can be retried safely.
-/// Bodies created from bytes, text, JSON, forms, URL search params, blobs, and
-/// replayable stream factories are replayable. Bodies created from a raw
-/// `Stream<List<int>>` are one-shot.
-final class Body {
-  Body._({
-    required this.kind,
+/// Bodies created from raw `Stream<List<int>>` values are one-shot; pass an
+/// `ht.Body(stream)` when tee-based clone semantics are desired.
+final class Body extends ht.Body {
+  /// Creates a request body from any `ht.BodyInit` value.
+  Body([super.init])
+    : replayable = _defaultReplayable(init),
+      _streamUpload = _defaultStreamUpload(init),
+      super();
+
+  Body._withPolicy(
+    super.init, {
     required this.replayable,
-    required _HtBodyFactory open,
-    this.contentLength,
-    this.contentType,
-  }) : _open = open;
+    required bool streamUpload,
+  }) : _streamUpload = streamUpload,
+       super();
 
-  /// The original body source kind.
-  final BodyKind kind;
-
-  /// Whether [open] can be called more than once.
+  /// Whether [clone] can create an independent body for another attempt.
   final bool replayable;
 
-  /// The known content length, or `null` when unknown.
-  final int? contentLength;
+  final bool _streamUpload;
 
-  /// The content type supplied by the body source, or `null`.
-  final String? contentType;
-  final _HtBodyFactory _open;
-  bool _used = false;
-
-  /// Creates an empty replayable body.
-  static Body empty() {
-    return Body.fromBytes(const <int>[], kind: BodyKind.empty);
-  }
-
-  /// Creates a replayable body from [bytes].
-  static Body fromBytes(List<int> bytes, {BodyKind kind = BodyKind.bytes}) {
-    final data = Uint8List.fromList(bytes);
-    return Body._(
-      kind: kind,
+  @override
+  Body clone() {
+    if (!replayable) {
+      throw const BodyStateError('Body is not replayable.');
+    }
+    return Body._withPolicy(
+      super.clone(),
       replayable: true,
-      contentLength: data.length,
-      open: () => ht.Body(Uint8List.fromList(data)),
+      streamUpload: _streamUpload,
     );
   }
 
-  /// Creates a replayable text body.
-  static Body fromText(
-    String value, {
-    Encoding encoding = utf8,
-    String contentType = 'text/plain;charset=UTF-8',
-  }) {
-    final data = encoding.encode(value);
-    return Body._(
-      kind: BodyKind.text,
-      replayable: true,
-      contentLength: data.length,
-      contentType: contentType,
-      open: () => ht.Body(Uint8List.fromList(data)),
-    );
-  }
-
-  /// Creates a replayable JSON body.
-  static Body fromJson(
-    Object? value, {
-    String contentType = 'application/json; charset=utf-8',
-  }) {
-    final data = utf8.encode(jsonEncode(value));
-    return Body._(
-      kind: BodyKind.json,
-      replayable: true,
-      contentLength: data.length,
-      contentType: contentType,
-      open: () => ht.Body(Uint8List.fromList(data)),
-    );
-  }
-
-  /// Creates a one-shot streaming body.
-  static Body stream(Stream<List<int>> stream, {int? contentLength}) {
-    var consumed = false;
-    return Body._(
-      kind: BodyKind.stream,
-      replayable: false,
-      contentLength: contentLength,
-      open: () {
-        if (consumed) {
-          throw const BodyStateError('Request body stream was already used.');
-        }
-        consumed = true;
-        return ht.Body(stream);
-      },
-    );
-  }
-
-  /// Creates a replayable streaming body from an [open] factory.
-  static Body replayableStream(
-    BodyStreamFactory open, {
-    int? contentLength,
-    BodyKind kind = BodyKind.stream,
-    String? contentType,
-  }) {
-    return Body._(
-      kind: kind,
-      replayable: true,
-      contentLength: contentLength,
-      contentType: contentType,
-      open: () => ht.Body(open()),
-    );
-  }
-
-  /// Converts common request body inputs to a [Body].
-  ///
-  /// Returns `null` for `null`. Throws [ArgumentError] for unsupported inputs.
-  static Body? from(Object? value) {
-    return switch (value) {
-      null => null,
-      Body() => value,
-      String() => Body.fromText(value),
-      Uint8List() => Body.fromBytes(value),
-      ByteBuffer() => Body.fromBytes(value.asUint8List()),
-      List<int>() => Body.fromBytes(value),
-      ht.FormData() => Body.fromFormData(value),
-      ht.URLSearchParams() => Body.fromUrlSearchParams(value),
-      ht.Blob() => Body.fromBlob(value),
-      ht.Body() => Body._fromHtBody(value),
-      Stream<List<int>>() => Body.stream(value),
-      _ => Body._fromHtBody(ht.Body(value)),
+  static bool _defaultReplayable(Object? init) {
+    return switch (init) {
+      Body() => init.replayable,
+      ht.Body() => true,
+      Stream<List<int>>() => false,
+      _ => true,
     };
   }
 
-  /// Creates a replayable body backed by an upstream [ht.Body].
-  static Body _fromHtBody(ht.Body body) {
-    final source = body.clone();
-    return Body._(
-      kind: BodyKind.stream,
-      replayable: true,
-      contentType: source.contentType,
-      open: () => source.clone(),
-    );
+  static bool _defaultStreamUpload(Object? init) {
+    return switch (init) {
+      Body() => init._streamUpload,
+      ht.Body() =>
+        _isMultipart(init.contentType) || knownBodyLength(init) == null,
+      Stream<List<int>>() || ht.FormData() || ht.Blob() => true,
+      _ => false,
+    };
   }
+}
 
-  /// Creates a replayable multipart form body.
-  static Body fromFormData(ht.FormData formData) {
-    final encoded = formData.encodeMultipart();
-    return Body._(
-      kind: BodyKind.multipart,
-      replayable: true,
-      contentLength: encoded.contentLength,
-      contentType: encoded.contentType,
-      open: () => ht.Body(encoded.stream),
-    );
+/// Converts request body inputs to an Oxy [Body].
+Body? requestBodyFrom(Object? value) {
+  return value == null
+      ? null
+      : value is Body
+      ? value
+      : Body(value);
+}
+
+/// Creates a JSON request body.
+Body requestJsonBody(Object? value) {
+  return Body(ht.Blob([jsonEncode(value)], 'application/json; charset=utf-8'));
+}
+
+/// Returns a body byte length when it is available without consuming [body].
+int? knownBodyLength(ht.Body? body) {
+  if (body == null) {
+    return null;
   }
-
-  /// Creates a replayable `application/x-www-form-urlencoded` body.
-  static Body fromUrlSearchParams(ht.URLSearchParams params) {
-    final data = utf8.encode(params.toString());
-    return Body._(
-      kind: BodyKind.form,
-      replayable: true,
-      contentLength: data.length,
-      contentType: ht.Body(params).contentType,
-      open: () => ht.Body(Uint8List.fromList(data)),
-    );
+  try {
+    return body.size;
+  } on UnsupportedError {
+    return null;
   }
+}
 
-  /// Creates a replayable body from a [ht.Blob].
-  static Body fromBlob(ht.Blob blob) {
-    return Body._(
-      kind: BodyKind.file,
-      replayable: true,
-      contentLength: blob.size,
-      contentType: blob.type.isEmpty ? null : blob.type,
-      open: () => ht.Body(blob),
-    );
-  }
+/// Whether web transport should upload [body] as a stream.
+bool streamsRequestBody(Body? body) {
+  return body?._streamUpload ?? false;
+}
 
-  /// Opens the body stream.
-  ///
-  /// Throws [BodyStateError] if this body is not replayable and was already
-  /// opened.
-  Stream<Uint8List> open() {
-    if (!replayable) {
-      if (_used) {
-        throw const BodyStateError('Body is not replayable.');
-      }
-      _used = true;
-    }
-
-    return _open().stream;
-  }
-
-  /// Reads the body as bytes.
-  ///
-  /// Throws [BodyTooLargeError] if [maxBytes] is set and the body exceeds it.
-  Future<Uint8List> bytes({int? maxBytes}) async {
-    final builder = BytesBuilder(copy: false);
-    await for (final chunk in open()) {
-      builder.add(chunk);
-      if (maxBytes != null && builder.length > maxBytes) {
-        throw BodyTooLargeError(limit: maxBytes);
-      }
-    }
-    return builder.takeBytes();
-  }
-
-  /// Reads the body as text using [encoding].
-  Future<String> text({Encoding encoding = utf8, int? maxBytes}) async {
-    return encoding.decode(await bytes(maxBytes: maxBytes));
-  }
-
-  /// Reads and decodes the body as JSON.
-  Future<Object?> json({int? maxBytes}) async {
-    return jsonDecode(await text(maxBytes: maxBytes));
-  }
+bool _isMultipart(String? contentType) {
+  return contentType?.toLowerCase().startsWith('multipart/form-data') ?? false;
 }
 
 /// A response body with replayability and content length metadata.
@@ -237,7 +108,7 @@ final class Body {
 final class ResponseBody {
   ResponseBody._({
     required bool replayable,
-    required BodyStreamFactory open,
+    required _BodyStreamFactory open,
     this.contentLength,
   }) : _replayable = replayable,
        _open = open;
@@ -246,7 +117,7 @@ final class ResponseBody {
 
   /// The known content length, or `null` when unknown.
   final int? contentLength;
-  final BodyStreamFactory _open;
+  final _BodyStreamFactory _open;
   bool _used = false;
 
   /// Whether [open] can be called more than once.

--- a/lib/src/core/body.dart
+++ b/lib/src/core/body.dart
@@ -9,6 +9,8 @@ import 'errors.dart';
 /// Opens a fresh byte stream for a replayable body.
 typedef _BodyStreamFactory = Stream<List<int>> Function();
 
+const _bufferedUpstreamBodyLimit = 64 * 1024;
+
 /// A request body backed by `ht.Body`.
 ///
 /// Oxy uses [replayable] to decide whether a request can be retried safely.
@@ -64,13 +66,16 @@ final class Body extends ht.Body {
   }
 
   static bool _streamsUpstreamBody(ht.Body body) {
-    if (knownBodyLength(body) == null) {
+    final length = knownBodyLength(body);
+    if (length == null) {
       return true;
     }
 
     final contentType = body.contentType?.toLowerCase();
-    if (contentType == null ||
-        contentType == 'text/plain;charset=utf-8' ||
+    if (contentType == null) {
+      return length > _bufferedUpstreamBodyLimit;
+    }
+    if (contentType == 'text/plain;charset=utf-8' ||
         contentType == 'application/x-www-form-urlencoded;charset=utf-8') {
       return false;
     }

--- a/lib/src/core/request.dart
+++ b/lib/src/core/request.dart
@@ -14,7 +14,7 @@ import '../options.dart';
 /// final request = Request(
 ///   '/users',
 ///   method: 'POST',
-///   body: Body.fromJson({'name': 'oxy'}),
+///   body: Blob(['{"name":"oxy"}'], 'application/json; charset=utf-8'),
 /// );
 /// ```
 final class Request {
@@ -29,7 +29,7 @@ final class Request {
          method: method,
          uri: _parseUri(url),
          headers: Headers(headers),
-         body: Body.from(body),
+         body: requestBodyFrom(body),
          options: options ?? const RequestOptions(),
          attributes: attributes,
        );

--- a/lib/src/transport/transport.native.dart
+++ b/lib/src/transport/transport.native.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import '../core/body.dart';
 import '../core/errors.dart';
 import '../core/headers.dart';
 import '../core/request.dart';
@@ -195,9 +196,9 @@ final class NativeTransport implements Transport {
 
     final body = request.body;
     if (body != null) {
-      if (body.contentLength != null &&
-          !request.headers.has('content-length')) {
-        httpRequest.headers.contentLength = body.contentLength!;
+      final contentLength = knownBodyLength(body);
+      if (contentLength != null && !request.headers.has('content-length')) {
+        httpRequest.headers.contentLength = contentLength;
       }
       if (body.contentType != null && !request.headers.has('content-type')) {
         httpRequest.headers.set('content-type', body.contentType!);
@@ -222,10 +223,10 @@ final class NativeTransport implements Transport {
       return;
     }
 
-    final total = body.contentLength;
+    final total = knownBodyLength(body);
     var transferred = 0;
 
-    final chunks = StreamIterator<Uint8List>(body.open());
+    final chunks = StreamIterator<Uint8List>(body.stream());
     Future<void>? cancelFuture;
     Future<void> cancelChunks() {
       return cancelFuture ??= chunks.cancel();

--- a/lib/src/transport/transport.web.dart
+++ b/lib/src/transport/transport.web.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 
 import '../core/body.dart';
@@ -30,10 +32,24 @@ extension type JSArrayStatic._(JSObject _) {
   external static bool isArray(JSAny? value);
 }
 
+@JS('Object')
+extension type JSObjectStatic._(JSObject _) {
+  external static JSObject defineProperty(
+    JSObject object,
+    String property,
+    JSObject descriptor,
+  );
+}
+
+extension type PropertyDescriptor._(JSObject _) implements JSObject {
+  external factory PropertyDescriptor({JSFunction get});
+}
+
 @JS('Headers')
 extension type WebHeaders._(JSObject _) implements JSObject {
   external factory WebHeaders();
   external void append(String name, String value);
+  external bool has(String name);
   external ArrayIterator entries();
 }
 
@@ -65,6 +81,8 @@ extension type RequestInit._(JSObject _) implements JSObject {
 @JS('Request')
 extension type WebRequest._(JSObject _) implements JSObject {
   external factory WebRequest(String input, RequestInit init);
+  external ReadableStream? get body;
+  external WebHeaders get headers;
 }
 
 @JS('Response')
@@ -81,7 +99,15 @@ extension type WebResponse._(JSObject _) implements JSObject {
 @JS('fetch')
 external JSPromise<WebResponse> webFetch(WebRequest request);
 
+bool? _requestStreamsSupported;
+bool _didWarnRequestStreamFallback = false;
+
 final class WebTransport implements Transport {
+  WebTransport({bool? requestStreamsSupported})
+    : _requestStreamsSupportedOverride = requestStreamsSupported;
+
+  final bool? _requestStreamsSupportedOverride;
+
   @override
   PlatformCapability get capability => PlatformCapability.web;
 
@@ -111,7 +137,10 @@ final class WebTransport implements Transport {
     _bindAbort(controller, context);
 
     final requestBody = request.body;
-    final streamBody = streamsRequestBody(requestBody);
+    final streamBody = shouldStreamRequestBody(
+      requestBody,
+      requestStreamsSupported: _supportsRequestStreams,
+    );
     final contentLength = knownBodyLength(requestBody);
     final requestBodySent =
         streamBody && context.timeoutPolicy.firstByte != null
@@ -408,6 +437,64 @@ final class WebTransport implements Transport {
       301 || 302 || 303 || 307 || 308 => true,
       _ => false,
     };
+  }
+
+  bool shouldStreamRequestBody(
+    Body? body, {
+    required bool requestStreamsSupported,
+  }) {
+    if (!streamsRequestBody(body)) {
+      return false;
+    }
+    if (requestStreamsSupported) {
+      return true;
+    }
+    _warnRequestStreamFallback();
+    return false;
+  }
+
+  bool get _supportsRequestStreams {
+    return _requestStreamsSupportedOverride ??
+        (_requestStreamsSupported ??= _detectRequestStreamsSupported());
+  }
+
+  bool _detectRequestStreamsSupported() {
+    try {
+      var duplexAccessed = false;
+      final init = JSObject()
+        ..['method'] = 'POST'.toJS
+        ..['body'] = ReadableStream(UnderlyingSource());
+      JSObjectStatic.defineProperty(
+        init,
+        'duplex',
+        PropertyDescriptor(
+          get: (() {
+            duplexAccessed = true;
+            return 'half'.toJS;
+          }).toJS,
+        ),
+      );
+      final request = WebRequest('https://example.com/', RequestInit._(init));
+      return duplexAccessed &&
+          request.body != null &&
+          !request.headers.has('content-type');
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void _warnRequestStreamFallback() {
+    assert(() {
+      if (!_didWarnRequestStreamFallback) {
+        _didWarnRequestStreamFallback = true;
+        developer.log(
+          'Fetch request streams are not supported in this browser; '
+          'buffering the request body before upload.',
+          name: 'oxy.web',
+        );
+      }
+      return true;
+    }());
   }
 
   bool _isForbiddenRequestHeader(String name) {

--- a/lib/src/transport/transport.web.dart
+++ b/lib/src/transport/transport.web.dart
@@ -111,7 +111,8 @@ final class WebTransport implements Transport {
     _bindAbort(controller, context);
 
     final requestBody = request.body;
-    final streamBody = _shouldStreamRequestBody(requestBody);
+    final streamBody = streamsRequestBody(requestBody);
+    final contentLength = knownBodyLength(requestBody);
     final requestBodySent =
         streamBody && context.timeoutPolicy.firstByte != null
         ? Completer<void>()
@@ -126,7 +127,7 @@ final class WebTransport implements Transport {
 
     if (requestBody != null) {
       if (streamBody) {
-        final stream = _withSendTimeout(requestBody.open(), context, request);
+        final stream = _withSendTimeout(requestBody.stream(), context, request);
         init.body = toWebReadableStream(
           requestBodySent == null
               ? stream
@@ -156,8 +157,8 @@ final class WebTransport implements Transport {
 
     context.onSendProgress?.call(
       TransferProgress(
-        transferred: streamBody ? 0 : (requestBody?.contentLength ?? 0),
-        total: requestBody?.contentLength,
+        transferred: streamBody ? 0 : (contentLength ?? 0),
+        total: contentLength,
       ),
     );
 
@@ -405,13 +406,6 @@ final class WebTransport implements Transport {
   bool _isRedirect(int status) {
     return switch (status) {
       301 || 302 || 303 || 307 || 308 => true,
-      _ => false,
-    };
-  }
-
-  bool _shouldStreamRequestBody(Body? body) {
-    return switch (body?.kind) {
-      BodyKind.stream || BodyKind.multipart || BodyKind.file => true,
       _ => false,
     };
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  ht: ^0.5.0
+  ht: ^0.6.0
   http_parser: ^4.1.2
   ocookie: ^0.3.0
   patchwork: ^0.5.0

--- a/test/client_browser_test.dart
+++ b/test/client_browser_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 import 'dart:js_interop';
 
+import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
 import 'package:oxy/src/transport/transport.web.dart' as web;
 import 'package:oxy/src/transport/web_stream_utils.dart';
@@ -48,6 +49,16 @@ void main() {
     expect(
       transport.shouldStreamRequestBody(body, requestStreamsSupported: false),
       isFalse,
+    );
+  });
+
+  test('web transport preserves wrapped ht Body upload streams', () {
+    final body = Body(ht.Body(Blob(['hello'], 'text/plain')));
+    final transport = web.WebTransport();
+
+    expect(
+      transport.shouldStreamRequestBody(body, requestStreamsSupported: true),
+      isTrue,
     );
   });
 

--- a/test/client_browser_test.dart
+++ b/test/client_browser_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:typed_data';
 
 import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
@@ -92,6 +93,17 @@ void main() {
         requestStreamsSupported: true,
       ),
       isFalse,
+    );
+  });
+
+  test('web transport streams large untyped upstream ht Body payloads', () {
+    final body = Body(ht.Body(Blob([Uint8List(128 * 1024)])));
+    final transport = web.WebTransport();
+
+    expect(body.contentType, isNull);
+    expect(
+      transport.shouldStreamRequestBody(body, requestStreamsSupported: true),
+      isTrue,
     );
   });
 

--- a/test/client_browser_test.dart
+++ b/test/client_browser_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:js_interop';
 
 import 'package:oxy/oxy.dart';
+import 'package:oxy/src/transport/transport.web.dart' as web;
 import 'package:oxy/src/transport/web_stream_utils.dart';
 import 'package:test/test.dart';
 
@@ -34,6 +35,20 @@ void main() {
     );
 
     await expectLater(client.get(url), throwsA(isA<PolicyError>()));
+  });
+
+  test('web transport buffers uploads when fetch streams are unsupported', () {
+    final body = Body(Blob(['hello'], 'text/plain'));
+    final transport = web.WebTransport();
+
+    expect(
+      transport.shouldStreamRequestBody(body, requestStreamsSupported: true),
+      isTrue,
+    );
+    expect(
+      transport.shouldStreamRequestBody(body, requestStreamsSupported: false),
+      isFalse,
+    );
   });
 
   test('web response stream read failures become NetworkError', () async {

--- a/test/client_browser_test.dart
+++ b/test/client_browser_test.dart
@@ -6,6 +6,7 @@ import 'dart:js_interop';
 
 import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
+import 'package:oxy/src/core/body.dart' as core;
 import 'package:oxy/src/transport/transport.web.dart' as web;
 import 'package:oxy/src/transport/web_stream_utils.dart';
 import 'package:test/test.dart';
@@ -59,6 +60,17 @@ void main() {
     expect(
       transport.shouldStreamRequestBody(body, requestStreamsSupported: true),
       isTrue,
+    );
+  });
+
+  test('web transport buffers JSON request bodies', () {
+    final body = core.requestJsonBody({'name': 'oxy'});
+    final transport = web.WebTransport();
+
+    expect(body.contentType, 'application/json; charset=utf-8');
+    expect(
+      transport.shouldStreamRequestBody(body, requestStreamsSupported: true),
+      isFalse,
     );
   });
 

--- a/test/client_browser_test.dart
+++ b/test/client_browser_test.dart
@@ -62,6 +62,27 @@ void main() {
     );
   });
 
+  test('web transport buffers small upstream ht Body payloads', () {
+    final textBody = Body(ht.Body('hello'));
+    final bytesBody = Body(ht.Body([1, 2, 3]));
+    final transport = web.WebTransport();
+
+    expect(
+      transport.shouldStreamRequestBody(
+        textBody,
+        requestStreamsSupported: true,
+      ),
+      isFalse,
+    );
+    expect(
+      transport.shouldStreamRequestBody(
+        bytesBody,
+        requestStreamsSupported: true,
+      ),
+      isFalse,
+    );
+  });
+
   test('web response stream read failures become NetworkError', () async {
     void start(ReadableByteStreamController controller) {
       controller.error('broken'.toJS);

--- a/test/client_vm_test.dart
+++ b/test/client_vm_test.dart
@@ -254,13 +254,11 @@ void main() {
         ),
       );
       addTearDown(client.close);
-      final body = Body.replayableStream(
-        () async* {
+      final body = Body(
+        (() async* {
           await Future<void>.delayed(const Duration(milliseconds: 50));
           yield utf8.encode('payload');
-        },
-        contentLength: 7,
-        contentType: 'text/plain',
+        })(),
       );
 
       final response = await client.post('/echo', body: body);

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
+import 'package:oxy/src/core/body.dart' as internal;
 import 'package:oxy/src/transport/transport.stub.dart' as stub;
 import 'package:test/test.dart';
 
@@ -131,6 +132,15 @@ void main() {
       );
       expect(await body.clone().text(), 'q=oxy&page=1');
       expect(await body.clone().text(), 'q=oxy&page=1');
+    });
+
+    test('keeps JSON request bodies on the buffered web upload path', () async {
+      final body = internal.requestJsonBody({'ok': true});
+
+      expect(body.contentType, 'application/json; charset=utf-8');
+      expect(body.size, 11);
+      expect(internal.streamsRequestBody(body), isFalse);
+      expect(await body.clone().text(), '{"ok":true}');
     });
 
     test('accepts ht Body as replayable upstream body', () async {

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 
 import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
-import 'package:oxy/src/core/body.dart' as internal;
 import 'package:oxy/src/transport/transport.stub.dart' as stub;
 import 'package:test/test.dart';
 
@@ -132,15 +131,6 @@ void main() {
       );
       expect(await body.clone().text(), 'q=oxy&page=1');
       expect(await body.clone().text(), 'q=oxy&page=1');
-    });
-
-    test('keeps JSON request bodies on the buffered web upload path', () async {
-      final body = internal.requestJsonBody({'ok': true});
-
-      expect(body.contentType, 'application/json; charset=utf-8');
-      expect(body.size, 11);
-      expect(internal.streamsRequestBody(body), isFalse);
-      expect(await body.clone().text(), '{"ok":true}');
     });
 
     test('accepts ht Body as replayable upstream body', () async {

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -38,32 +38,38 @@ void main() {
   });
 
   group('Body', () {
-    test('marks bytes and json bodies as replayable', () async {
-      final bytes = Body.fromBytes([1, 2, 3]);
-      final text = Body.from('hello')!;
-      final json = Body.fromJson({'ok': true});
+    test('inherits ht body primitive APIs', () async {
+      final text = Body('hello');
 
-      expect(bytes.replayable, isTrue);
-      expect(await bytes.bytes(), [1, 2, 3]);
-      expect(await bytes.bytes(), [1, 2, 3]);
-      expect(text.kind, BodyKind.text);
+      expect(text, isA<ht.Body>());
+      expect(text, isA<Blob>());
+      expect(text, isA<Stream<Uint8List>>());
+      expect(text.replayable, isTrue);
+      expect(text.size, 5);
+      expect(text.type, 'text/plain;charset=utf-8');
       expect(text.contentType, 'text/plain;charset=UTF-8');
+      expect(text.bodyUsed, isFalse);
+
+      final clone = text.clone();
+      expect(clone, isA<Body>());
+      expect(await clone.text(), 'hello');
+      expect(text.bodyUsed, isFalse);
       expect(await text.text(), 'hello');
-      expect(json.contentType, contains('application/json'));
-      expect(utf8.decode(await json.bytes()), '{"ok":true}');
+      expect(text.bodyUsed, isTrue);
+      expect(text.text(), throwsStateError);
     });
 
-    test('isolates replayable byte reads from caller mutation', () async {
-      final body = Body.fromBytes([1, 2, 3]);
+    test('isolates cloned byte reads from caller mutation', () async {
+      final body = Body([1, 2, 3]);
 
-      final first = await body.bytes();
+      final first = await body.clone().bytes();
       first[0] = 9;
 
-      expect(await body.bytes(), [1, 2, 3]);
+      expect(await body.clone().bytes(), [1, 2, 3]);
     });
 
     test('protects one-shot streams from accidental replay', () async {
-      final body = Body.stream(
+      final body = Body(
         Stream<Uint8List>.fromIterable([
           Uint8List.fromList([1]),
         ]),
@@ -71,7 +77,8 @@ void main() {
 
       expect(body.replayable, isFalse);
       expect(await body.bytes(), [1]);
-      expect(body.bytes(), throwsA(isA<BodyStateError>()));
+      expect(body.bytes(), throwsStateError);
+      expect(body.clone, throwsA(isA<BodyStateError>()));
     });
 
     test('accepts built-in form primitives backed by ht', () async {
@@ -81,65 +88,60 @@ void main() {
           'file',
           Multipart.blob(Blob(['hello'], 'text/plain'), 'a.txt'),
         );
-      final body = Body.from(form)!;
+      final body = Body(form);
 
-      expect(body.kind, BodyKind.multipart);
       expect(body.replayable, isTrue);
       expect(body.contentType, startsWith('multipart/form-data; boundary='));
-      expect(body.contentLength, greaterThan(0));
+      expect(body.size, greaterThan(0));
 
       final boundary = body.contentType!.split('boundary=').last;
-      final text = utf8.decode(await body.bytes());
+      final text = utf8.decode(await body.clone().bytes());
       expect(text, startsWith('--$boundary\r\n'));
       expect(text, endsWith('--$boundary--\r\n'));
       expect(text, contains('name="name"'));
       expect(text, contains('oxy'));
       expect(text, contains('filename="a.txt"'));
-      expect(utf8.decode(await body.bytes()), text);
+      expect(utf8.decode(await body.clone().bytes()), text);
     });
 
     test('treats Blob and File bodies as streaming file-like bodies', () async {
-      final body = Body.from(Blob(['hello'], 'text/plain'))!;
-      final fileBody = Body.from(File(['file'], 'a.txt', type: 'text/plain'))!;
+      final body = Body(Blob(['hello'], 'text/plain'));
+      final fileBody = Body(File(['file'], 'a.txt', type: 'text/plain'));
 
-      expect(body.kind, BodyKind.file);
       expect(body.replayable, isTrue);
-      expect(body.contentLength, 5);
+      expect(body.size, 5);
       expect(body.contentType, 'text/plain');
-      expect(await body.text(), 'hello');
-      expect(await body.text(), 'hello');
+      expect(await body.clone().text(), 'hello');
+      expect(await body.clone().text(), 'hello');
 
-      expect(fileBody.kind, BodyKind.file);
       expect(fileBody.replayable, isTrue);
-      expect(fileBody.contentLength, 4);
+      expect(fileBody.size, 4);
       expect(fileBody.contentType, 'text/plain');
-      expect(await fileBody.text(), 'file');
-      expect(await fileBody.text(), 'file');
+      expect(await fileBody.clone().text(), 'file');
+      expect(await fileBody.clone().text(), 'file');
     });
 
     test('accepts URLSearchParams as replayable form body', () async {
       final params = URLSearchParams({'q': 'oxy', 'page': '1'});
-      final body = Body.from(params)!;
+      final body = Body(params);
 
-      expect(body.kind, BodyKind.form);
       expect(
         body.contentType,
         'application/x-www-form-urlencoded;charset=UTF-8',
       );
-      expect(await body.text(), 'q=oxy&page=1');
-      expect(await body.text(), 'q=oxy&page=1');
+      expect(await body.clone().text(), 'q=oxy&page=1');
+      expect(await body.clone().text(), 'q=oxy&page=1');
     });
 
     test('accepts ht Body as replayable upstream body', () async {
       final upstream = ht.Body('hello');
-      final body = Body.from(upstream)!;
+      final body = Body(upstream);
 
-      expect(body.kind, BodyKind.stream);
       expect(body.replayable, isTrue);
-      expect(body.contentLength, isNull);
+      expect(body.size, 5);
       expect(body.contentType, 'text/plain;charset=UTF-8');
-      expect(await body.text(), 'hello');
-      expect(await body.text(), 'hello');
+      expect(await body.clone().text(), 'hello');
+      expect(await body.clone().text(), 'hello');
       expect(upstream.bodyUsed, isFalse);
     });
 
@@ -150,20 +152,20 @@ void main() {
           utf8.encode('stream'),
         ]),
       );
-      final body = Body.from(upstream)!;
+      final body = Body(upstream);
 
       expect(body.replayable, isTrue);
-      expect(await body.text(), 'hello stream');
-      expect(await body.text(), 'hello stream');
+      expect(() => body.size, throwsUnsupportedError);
+      expect(await body.clone().text(), 'hello stream');
+      expect(await body.clone().text(), 'hello stream');
     });
 
     test('accepts ByteBuffer through ht-compatible body input', () async {
       final buffer = Uint8List.fromList([1, 2, 3]).buffer;
-      final body = Body.from(buffer)!;
+      final body = Body(buffer);
 
-      expect(body.kind, BodyKind.bytes);
       expect(body.replayable, isTrue);
-      expect(body.contentLength, 3);
+      expect(body.size, 3);
       expect(await body.bytes(), [1, 2, 3]);
     });
   });

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
 import 'package:oxy/testing.dart';
 import 'package:test/test.dart';
@@ -143,6 +144,32 @@ void main() {
     expect(result.isFailure, isTrue);
     expect(result.error, isA<NetworkError>());
   });
+
+  test(
+    'uses original replayable stream body when replay is disabled',
+    () async {
+      final body = Body(ht.Body(Stream<List<int>>.value([1, 2, 3])));
+      final client = Client(
+        ClientOptions(
+          retryPolicy: const RetryPolicy(maxRetries: 0),
+          redirectPolicy: RedirectPolicy.manual,
+          transport: MockTransport((request, context) async {
+            expect(identical(request.body, body), isTrue);
+            expect(await request.body!.bytes(), [1, 2, 3]);
+            return Response.text('ok');
+          }),
+        ),
+      );
+
+      final response = await client.post(
+        'https://example.com/upload',
+        body: body,
+      );
+
+      expect(await response.text(), 'ok');
+      expect(body.bodyUsed, isTrue);
+    },
+  );
 
   test('per-request headers override client defaults', () async {
     late Request captured;


### PR DESCRIPTION
## Summary
- Upgrade to ht ^0.6.0 and make Oxy request Body extend ht.Body directly.
- Remove Oxy-specific request BodyKind, Body.from*, Body.open(), contentLength, and BodyStreamFactory surface in favor of upstream ht.Body APIs.
- Clone replayable request bodies for retry attempts and preserved-method redirects so each attempt consumes an independent ht.Body.

## Breaking Changes
- Request Body now uses the ht.Body primitive API: stream(), bytes(), arrayBuffer(), text(), json(), blob(), slice(), clone(), bodyUsed, size, type, and contentType.
- Raw Stream<List<int>> inputs remain one-shot; pass ht.Body(stream) when upstream clone semantics are desired.

## Validation
- dart run patchwork apply
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test test/core_test.dart -p vm
- dart test test/client_vm_test.dart -p vm
- dart test -p vm -p node -p chrome

Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed Oxy-specific request-body APIs; use upstream `ht.Body` behavior/APIs instead.
  * `package:oxy/oxy.dart` now only re-exports `Body` and `ResponseBody`.
  * Upgraded dependency to `ht ^0.6.0`.
* **Changed**
  * Replayable request bodies are cloned for retries and method-redirect attempts.
  * Redirects now explicitly preserve or clear request bodies when methods change (e.g., to `GET`).
  * Improved request upload handling: `content-length` and progress now use known body length; native/web transports updated for streaming decisions.
* **Tests**
  * Updated and added native and browser coverage for request replay and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->