### PR TITLE
perf: add real HTTP client benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ Choose Oxy when you want:
 - `MockTransport` tests that exercise the real Oxy pipeline without opening a
   socket or running a server.
 
-Another package may be a better fit when `package:http` is enough, when `dio`
-already matches your Flutter app conventions, or when you want generated
-interfaces from `chopper` or `retrofit`.
-
 ## Quick Start
 
 ```sh

--- a/bench/baseline.dart
+++ b/bench/baseline.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ht/ht.dart' as ht;
+
+import 'src/data.dart';
+import 'src/runner.dart';
+
+final baselineSuite = BenchmarkSuite('baseline', <BenchmarkCase>[
+  SyncBenchmark(
+    group: 'json',
+    name: 'encode',
+    run: () {
+      consume(jsonEncode(jsonPayload));
+    },
+  ),
+  SyncBenchmark(
+    group: 'json',
+    name: 'decode',
+    run: () {
+      consume(jsonDecode(jsonText));
+    },
+  ),
+  SyncBenchmark(
+    group: 'bytes',
+    name: 'copy-1k',
+    run: () {
+      consume(Uint8List.fromList(smallBytes));
+    },
+  ),
+  SyncBenchmark(
+    group: 'headers',
+    name: 'create-8',
+    run: () {
+      consume(ht.Headers(headerPairs8));
+    },
+  ),
+  SyncBenchmark(
+    group: 'headers',
+    name: 'create-32',
+    run: () {
+      consume(ht.Headers(headerPairs32));
+    },
+  ),
+  SyncBenchmark(
+    group: 'headers',
+    name: 'iterate-32',
+    run: () {
+      consume(ht.Headers(headerPairs32).toList(growable: false));
+    },
+  ),
+  SyncBenchmark(
+    group: 'body',
+    name: 'construct-string',
+    run: () {
+      consume(ht.Body(jsonText));
+    },
+  ),
+  SyncBenchmark(
+    group: 'body',
+    name: 'clone-bytes',
+    run: () {
+      consume(ht.Body(largeBytes).clone());
+    },
+  ),
+  AsyncBenchmark(
+    group: 'body',
+    name: 'bytes-1k',
+    run: () async {
+      consume(await ht.Body(smallBytes).bytes());
+    },
+  ),
+]);

--- a/bench/dio.dart
+++ b/bench/dio.dart
@@ -1,159 +1,97 @@
-import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dio/dio.dart' as dio;
 
 import 'src/data.dart';
 import 'src/runner.dart';
+import 'src/server.dart';
 
 final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
-  SyncBenchmark(
-    group: 'request',
-    name: 'construct-options',
-    run: () {
-      consume(
-        dio.RequestOptions(
-          path: _uri.toString(),
-          method: 'GET',
-          headers: Map<String, String>.from(_headers8),
-        ),
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-empty',
+    run: () async {
+      final response = await _client.get<Object?>(
+        '/empty',
+        options: _headersOptions,
       );
+      consume(response.statusCode);
     },
   ),
-  SyncBenchmark(
-    group: 'request',
-    name: 'construct-post-json-options',
-    run: () {
-      consume(
-        dio.RequestOptions(
-          path: _uri.toString(),
-          method: 'POST',
-          headers: Map<String, String>.from(_jsonHeaders),
-          data: jsonPayload,
-        ),
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-json-decode',
+    run: () async {
+      final response = await _client.get<Map<String, Object?>>(
+        '/json',
+        options: _headersOptions,
       );
+      consume(response.data);
     },
   ),
   AsyncBenchmark(
-    group: 'client',
-    name: 'send-no-interceptors',
+    group: 'network',
+    name: 'get-bytes-64k',
     run: () async {
-      consume(await _client.getUri<Object?>(_uri, options: _headersOptions));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'post-json-body',
-    run: () async {
-      consume(await _client.postUri<Object?>(_uri, data: jsonPayload));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'send-5-interceptors',
-    run: () async {
-      consume(
-        await _interceptorClient.getUri<Object?>(
-          _uri,
-          options: _headersOptions,
-        ),
+      final response = await _client.get<List<int>>(
+        '/bytes-64k',
+        options: _bytesOptions,
       );
+      consume(response.data);
     },
   ),
   AsyncBenchmark(
-    group: 'response',
-    name: 'bytes-1k',
+    group: 'network',
+    name: 'post-json',
     run: () async {
-      consume(
-        await _client.getUri<List<int>>(_bytesUri, options: _bytesOptions),
+      final response = await _client.post<Map<String, Object?>>(
+        '/json',
+        data: jsonPayload,
+        options: _jsonOptions,
       );
+      consume(response.data);
     },
   ),
   AsyncBenchmark(
-    group: 'response',
-    name: 'json-decode',
+    group: 'network',
+    name: 'post-bytes-64k',
     run: () async {
-      consume(await _client.getUri<Map<String, Object?>>(_jsonUri));
+      final response = await _client.post<Object?>(
+        '/bytes-64k',
+        data: largeBytes,
+        options: _postBytesOptions,
+      );
+      consume(response.statusCode);
     },
   ),
 ]);
 
-final _uri = Uri.parse('https://example.test/users/42');
-final _jsonUri = Uri.parse('https://example.test/json');
-final _bytesUri = Uri.parse('https://example.test/bytes');
 final _headers8 = Map<String, String>.fromEntries(headerPairs8);
 const _jsonHeaders = <String, String>{
   'content-type': 'application/json; charset=utf-8',
 };
+const _octetHeaders = <String, String>{
+  'content-type': 'application/octet-stream',
+};
 final _headersOptions = dio.Options(headers: _headers8);
+final _jsonOptions = dio.Options(headers: _jsonHeaders);
 final _bytesOptions = dio.Options(responseType: dio.ResponseType.bytes);
+final _postBytesOptions = dio.Options(
+  headers: _octetHeaders,
+  responseType: dio.ResponseType.plain,
+);
 
-final _client = _createClient();
-final _interceptorClient = _createClient()
-  ..interceptors.addAll(
-    List<dio.Interceptor>.filled(5, const _NoopInterceptor()),
-  );
+dio.Dio? _clientInstance;
 
-dio.Dio _createClient() {
-  return dio.Dio(
+dio.Dio get _client {
+  return _clientInstance ??= dio.Dio(
     dio.BaseOptions(
+      baseUrl: benchmarkServer.baseUri.toString(),
       responseType: dio.ResponseType.json,
       validateStatus: (_) => true,
     ),
-  )..httpClientAdapter = const _StaticDioAdapter();
+  );
 }
 
-final class _StaticDioAdapter implements dio.HttpClientAdapter {
-  const _StaticDioAdapter();
-
-  @override
-  Future<dio.ResponseBody> fetch(
-    dio.RequestOptions options,
-    Stream<Uint8List>? requestStream,
-    Future<void>? cancelFuture,
-  ) async {
-    await requestStream?.drain<void>();
-    if (options.uri == _jsonUri) {
-      return dio.ResponseBody.fromString(
-        jsonText,
-        200,
-        headers: const <String, List<String>>{
-          'content-type': <String>['application/json; charset=utf-8'],
-        },
-      );
-    }
-    if (options.uri == _bytesUri) {
-      return dio.ResponseBody.fromBytes(
-        smallBytes,
-        200,
-        headers: <String, List<String>>{
-          'content-length': <String>[smallBytes.length.toString()],
-        },
-      );
-    }
-    return dio.ResponseBody.fromBytes(const <int>[], 200);
-  }
-
-  @override
-  void close({bool force = false}) {}
-}
-
-final class _NoopInterceptor extends dio.Interceptor {
-  const _NoopInterceptor();
-
-  @override
-  void onRequest(
-    dio.RequestOptions options,
-    dio.RequestInterceptorHandler handler,
-  ) {
-    handler.next(options);
-  }
-
-  @override
-  void onResponse(
-    dio.Response<dynamic> response,
-    dio.ResponseInterceptorHandler handler,
-  ) {
-    handler.next(response);
-  }
+Future<void> closeDioBenchmarks() async {
+  _clientInstance?.close(force: true);
+  _clientInstance = null;
 }

--- a/bench/dio.dart
+++ b/bench/dio.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart' as dio;
 
 import 'src/data.dart';
+import 'src/network.dart';
 import 'src/runner.dart';
 import 'src/server.dart';
 
@@ -13,6 +14,7 @@ final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
         '/empty',
         options: _headersOptions,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.statusCode);
     },
   ),
@@ -24,6 +26,7 @@ final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
         '/json',
         options: _headersOptions,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.data);
     },
   ),
@@ -35,6 +38,7 @@ final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
         '/bytes-64k',
         options: _bytesOptions,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.data);
     },
   ),
@@ -47,6 +51,7 @@ final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
         data: jsonPayload,
         options: _jsonOptions,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.data);
     },
   ),
@@ -59,23 +64,20 @@ final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
         data: largeBytes,
         options: _postBytesOptions,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.statusCode);
     },
   ),
 ]);
 
-final _headers8 = Map<String, String>.fromEntries(headerPairs8);
-const _jsonHeaders = <String, String>{
-  'content-type': 'application/json; charset=utf-8',
-};
-const _octetHeaders = <String, String>{
-  'content-type': 'application/octet-stream',
-};
-final _headersOptions = dio.Options(headers: _headers8);
-final _jsonOptions = dio.Options(headers: _jsonHeaders);
-final _bytesOptions = dio.Options(responseType: dio.ResponseType.bytes);
+final _headersOptions = dio.Options(headers: benchmarkHeaders);
+final _jsonOptions = dio.Options(headers: jsonHeaders);
+final _bytesOptions = dio.Options(
+  headers: benchmarkHeaders,
+  responseType: dio.ResponseType.bytes,
+);
 final _postBytesOptions = dio.Options(
-  headers: _octetHeaders,
+  headers: octetHeaders,
   responseType: dio.ResponseType.plain,
 );
 
@@ -86,7 +88,6 @@ dio.Dio get _client {
     dio.BaseOptions(
       baseUrl: benchmarkServer.baseUri.toString(),
       responseType: dio.ResponseType.json,
-      validateStatus: (_) => true,
     ),
   );
 }

--- a/bench/dio.dart
+++ b/bench/dio.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart' as dio;
+
+import 'src/data.dart';
+import 'src/runner.dart';
+
+final dioSuite = BenchmarkSuite('dio', <BenchmarkCase>[
+  SyncBenchmark(
+    group: 'request',
+    name: 'construct-options',
+    run: () {
+      consume(
+        dio.RequestOptions(
+          path: _uri.toString(),
+          method: 'GET',
+          headers: Map<String, String>.from(_headers8),
+        ),
+      );
+    },
+  ),
+  SyncBenchmark(
+    group: 'request',
+    name: 'construct-post-json-options',
+    run: () {
+      consume(
+        dio.RequestOptions(
+          path: _uri.toString(),
+          method: 'POST',
+          headers: Map<String, String>.from(_jsonHeaders),
+          data: jsonPayload,
+        ),
+      );
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'send-no-interceptors',
+    run: () async {
+      consume(await _client.getUri<Object?>(_uri, options: _headersOptions));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'post-json-body',
+    run: () async {
+      consume(await _client.postUri<Object?>(_uri, data: jsonPayload));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'send-5-interceptors',
+    run: () async {
+      consume(
+        await _interceptorClient.getUri<Object?>(
+          _uri,
+          options: _headersOptions,
+        ),
+      );
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'bytes-1k',
+    run: () async {
+      consume(
+        await _client.getUri<List<int>>(_bytesUri, options: _bytesOptions),
+      );
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'json-decode',
+    run: () async {
+      consume(await _client.getUri<Map<String, Object?>>(_jsonUri));
+    },
+  ),
+]);
+
+final _uri = Uri.parse('https://example.test/users/42');
+final _jsonUri = Uri.parse('https://example.test/json');
+final _bytesUri = Uri.parse('https://example.test/bytes');
+final _headers8 = Map<String, String>.fromEntries(headerPairs8);
+const _jsonHeaders = <String, String>{
+  'content-type': 'application/json; charset=utf-8',
+};
+final _headersOptions = dio.Options(headers: _headers8);
+final _bytesOptions = dio.Options(responseType: dio.ResponseType.bytes);
+
+final _client = _createClient();
+final _interceptorClient = _createClient()
+  ..interceptors.addAll(
+    List<dio.Interceptor>.filled(5, const _NoopInterceptor()),
+  );
+
+dio.Dio _createClient() {
+  return dio.Dio(
+    dio.BaseOptions(
+      responseType: dio.ResponseType.json,
+      validateStatus: (_) => true,
+    ),
+  )..httpClientAdapter = const _StaticDioAdapter();
+}
+
+final class _StaticDioAdapter implements dio.HttpClientAdapter {
+  const _StaticDioAdapter();
+
+  @override
+  Future<dio.ResponseBody> fetch(
+    dio.RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    await requestStream?.drain<void>();
+    if (options.uri == _jsonUri) {
+      return dio.ResponseBody.fromString(
+        jsonText,
+        200,
+        headers: const <String, List<String>>{
+          'content-type': <String>['application/json; charset=utf-8'],
+        },
+      );
+    }
+    if (options.uri == _bytesUri) {
+      return dio.ResponseBody.fromBytes(
+        smallBytes,
+        200,
+        headers: <String, List<String>>{
+          'content-length': <String>[smallBytes.length.toString()],
+        },
+      );
+    }
+    return dio.ResponseBody.fromBytes(const <int>[], 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final class _NoopInterceptor extends dio.Interceptor {
+  const _NoopInterceptor();
+
+  @override
+  void onRequest(
+    dio.RequestOptions options,
+    dio.RequestInterceptorHandler handler,
+  ) {
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    dio.Response<dynamic> response,
+    dio.ResponseInterceptorHandler handler,
+  ) {
+    handler.next(response);
+  }
+}

--- a/bench/http.dart
+++ b/bench/http.dart
@@ -1,86 +1,82 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:http/testing.dart' as http_testing;
 
 import 'src/data.dart';
 import 'src/runner.dart';
+import 'src/server.dart';
 
 final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
-  SyncBenchmark(
-    group: 'request',
-    name: 'construct-get',
-    run: () {
-      consume(http.Request('GET', _uri)..headers.addAll(_headers8));
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-empty',
+    run: () async {
+      final response = await _client.get(_uri('/empty'), headers: _headers8);
+      consume(response.statusCode);
     },
   ),
-  SyncBenchmark(
-    group: 'request',
-    name: 'construct-post-json',
-    run: () {
-      consume(
-        http.Request('POST', _uri)
-          ..headers.addAll(_jsonHeaders)
-          ..bodyBytes = utf8.encode(jsonText),
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-json-decode',
+    run: () async {
+      final response = await _client.get(_uri('/json'), headers: _headers8);
+      consume(jsonDecode(response.body));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-bytes-64k',
+    run: () async {
+      final response = await _client.get(
+        _uri('/bytes-64k'),
+        headers: _headers8,
       );
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'send-no-middleware',
-    run: () async {
-      consume(await _client.get(_uri, headers: _headers8));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'post-json-body',
-    run: () async {
-      consume(await _client.post(_uri, headers: _jsonHeaders, body: jsonText));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'response',
-    name: 'bytes-1k',
-    run: () async {
-      final response = await _client.get(_bytesUri);
       consume(response.bodyBytes);
     },
   ),
   AsyncBenchmark(
-    group: 'response',
-    name: 'json-decode',
+    group: 'network',
+    name: 'post-json',
     run: () async {
-      final response = await _client.get(_jsonUri);
+      final response = await _client.post(
+        _uri('/json'),
+        headers: _jsonHeaders,
+        body: jsonText,
+      );
       consume(jsonDecode(response.body));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'network',
+    name: 'post-bytes-64k',
+    run: () async {
+      final response = await _client.post(
+        _uri('/bytes-64k'),
+        headers: _octetHeaders,
+        body: largeBytes,
+      );
+      consume(response.statusCode);
     },
   ),
 ]);
 
-final _uri = Uri.parse('https://example.test/users/42');
-final _jsonUri = Uri.parse('https://example.test/json');
-final _bytesUri = Uri.parse('https://example.test/bytes');
 final _headers8 = Map<String, String>.fromEntries(headerPairs8);
 const _jsonHeaders = <String, String>{
   'content-type': 'application/json; charset=utf-8',
 };
+const _octetHeaders = <String, String>{
+  'content-type': 'application/octet-stream',
+};
 
-final _client = http_testing.MockClient.streaming((request, bodyStream) async {
-  await bodyStream.drain<void>();
-  if (request.url == _jsonUri) {
-    return http.StreamedResponse(
-      Stream<List<int>>.value(utf8.encode(jsonText)),
-      200,
-      headers: _jsonHeaders,
-    );
-  }
-  if (request.url == _bytesUri) {
-    return http.StreamedResponse(
-      Stream<List<int>>.value(smallBytes),
-      200,
-      contentLength: smallBytes.length,
-    );
-  }
-  return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
-});
+http.Client? _clientInstance;
+
+http.Client get _client {
+  return _clientInstance ??= http.Client();
+}
+
+Uri _uri(String path) => benchmarkServer.uri(path);
+
+Future<void> closeHttpBenchmarks() async {
+  _clientInstance?.close();
+  _clientInstance = null;
+}

--- a/bench/http.dart
+++ b/bench/http.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+
+import 'src/data.dart';
+import 'src/runner.dart';
+
+final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
+  SyncBenchmark(
+    group: 'request',
+    name: 'construct-get',
+    run: () {
+      consume(http.Request('GET', _uri)..headers.addAll(_headers8));
+    },
+  ),
+  SyncBenchmark(
+    group: 'request',
+    name: 'construct-post-json',
+    run: () {
+      consume(
+        http.Request('POST', _uri)
+          ..headers.addAll(_jsonHeaders)
+          ..bodyBytes = utf8.encode(jsonText),
+      );
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'send-no-middleware',
+    run: () async {
+      consume(await _client.get(_uri, headers: _headers8));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'post-json-body',
+    run: () async {
+      consume(await _client.post(_uri, headers: _jsonHeaders, body: jsonText));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'bytes-1k',
+    run: () async {
+      final response = await _client.get(_bytesUri);
+      consume(response.bodyBytes);
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'json-decode',
+    run: () async {
+      final response = await _client.get(_jsonUri);
+      consume(jsonDecode(response.body));
+    },
+  ),
+]);
+
+final _uri = Uri.parse('https://example.test/users/42');
+final _jsonUri = Uri.parse('https://example.test/json');
+final _bytesUri = Uri.parse('https://example.test/bytes');
+final _headers8 = Map<String, String>.fromEntries(headerPairs8);
+const _jsonHeaders = <String, String>{
+  'content-type': 'application/json; charset=utf-8',
+};
+
+final _client = http_testing.MockClient.streaming((request, bodyStream) async {
+  await bodyStream.drain<void>();
+  if (request.url == _jsonUri) {
+    return http.StreamedResponse(
+      Stream<List<int>>.value(utf8.encode(jsonText)),
+      200,
+      headers: _jsonHeaders,
+    );
+  }
+  if (request.url == _bytesUri) {
+    return http.StreamedResponse(
+      Stream<List<int>>.value(smallBytes),
+      200,
+      contentLength: smallBytes.length,
+    );
+  }
+  return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+});

--- a/bench/http.dart
+++ b/bench/http.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'src/data.dart';
+import 'src/network.dart';
 import 'src/runner.dart';
 import 'src/server.dart';
 
@@ -11,7 +12,11 @@ final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
     group: 'network',
     name: 'get-empty',
     run: () async {
-      final response = await _client.get(_uri('/empty'), headers: _headers8);
+      final response = await _client.get(
+        _uri('/empty'),
+        headers: benchmarkHeaders,
+      );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.statusCode);
     },
   ),
@@ -19,7 +24,11 @@ final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
     group: 'network',
     name: 'get-json-decode',
     run: () async {
-      final response = await _client.get(_uri('/json'), headers: _headers8);
+      final response = await _client.get(
+        _uri('/json'),
+        headers: benchmarkHeaders,
+      );
+      checkBenchmarkStatus(response.statusCode);
       consume(jsonDecode(response.body));
     },
   ),
@@ -29,8 +38,9 @@ final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
     run: () async {
       final response = await _client.get(
         _uri('/bytes-64k'),
-        headers: _headers8,
+        headers: benchmarkHeaders,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.bodyBytes);
     },
   ),
@@ -40,9 +50,10 @@ final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
     run: () async {
       final response = await _client.post(
         _uri('/json'),
-        headers: _jsonHeaders,
+        headers: jsonHeaders,
         body: jsonText,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(jsonDecode(response.body));
     },
   ),
@@ -52,21 +63,14 @@ final httpSuite = BenchmarkSuite('http', <BenchmarkCase>[
     run: () async {
       final response = await _client.post(
         _uri('/bytes-64k'),
-        headers: _octetHeaders,
+        headers: octetHeaders,
         body: largeBytes,
       );
+      checkBenchmarkStatus(response.statusCode);
       consume(response.statusCode);
     },
   ),
 ]);
-
-final _headers8 = Map<String, String>.fromEntries(headerPairs8);
-const _jsonHeaders = <String, String>{
-  'content-type': 'application/json; charset=utf-8',
-};
-const _octetHeaders = <String, String>{
-  'content-type': 'application/octet-stream',
-};
 
 http.Client? _clientInstance;
 

--- a/bench/main.dart
+++ b/bench/main.dart
@@ -1,0 +1,68 @@
+import 'baseline.dart';
+import 'dio.dart' as dio_suite;
+import 'http.dart' as http_suite;
+import 'oxy.dart';
+import 'src/runner.dart';
+
+final _suites = <String, BenchmarkSuite>{
+  baselineSuite.name: baselineSuite,
+  oxySuite.name: oxySuite,
+  http_suite.httpSuite.name: http_suite.httpSuite,
+  dio_suite.dioSuite.name: dio_suite.dioSuite,
+};
+
+void main(List<String> args) async {
+  final config = RunConfig.fromArgs(args);
+  if (config.showHelp) {
+    _printUsage();
+    return;
+  }
+
+  final suites = _selectSuites(config.suite);
+  final results = await measureSuites(config, suites);
+  if (results.isEmpty) {
+    throw ArgumentError(
+      'No benchmarks matched suite `${config.suite}`'
+      '${config.filter == null ? '' : ' and filter `${config.filter}`'}.',
+    );
+  }
+
+  printReport(config, results);
+}
+
+List<BenchmarkSuite> _selectSuites(String value) {
+  final selected = <BenchmarkSuite>[];
+  for (final name in value.split(',')) {
+    switch (name.trim()) {
+      case '':
+        break;
+      case 'all':
+        selected.addAll(_suites.values);
+      case 'clients':
+        selected.addAll(<BenchmarkSuite>[
+          oxySuite,
+          http_suite.httpSuite,
+          dio_suite.dioSuite,
+        ]);
+      case final suiteName:
+        final suite = _suites[suiteName];
+        if (suite == null) {
+          throw ArgumentError.value(suiteName, 'suite', 'Unknown suite');
+        }
+        selected.add(suite);
+    }
+  }
+  return selected.toSet().toList(growable: false);
+}
+
+void _printUsage() {
+  print('Usage: dart bench/main.dart [--quick] [--json] [--suite=<name>] ');
+  print('                           [--filter=<text>]');
+  print('');
+  print('Suites: baseline, oxy, http, dio, clients, all');
+  print('');
+  print('Examples:');
+  print('  dart bench/main.dart --quick');
+  print('  dart bench/main.dart --suite=clients --json');
+  print('  dart bench/main.dart --suite=oxy --filter=body');
+}

--- a/bench/main.dart
+++ b/bench/main.dart
@@ -3,6 +3,7 @@ import 'dio.dart' as dio_suite;
 import 'http.dart' as http_suite;
 import 'oxy.dart';
 import 'src/runner.dart';
+import 'src/server.dart';
 
 final _suites = <String, BenchmarkSuite>{
   baselineSuite.name: baselineSuite,
@@ -19,15 +20,29 @@ void main(List<String> args) async {
   }
 
   final suites = _selectSuites(config.suite);
-  final results = await measureSuites(config, suites);
-  if (results.isEmpty) {
-    throw ArgumentError(
-      'No benchmarks matched suite `${config.suite}`'
-      '${config.filter == null ? '' : ' and filter `${config.filter}`'}.',
-    );
+  final needsServer = suites.any(_needsBenchmarkServer);
+  if (needsServer) {
+    await startBenchmarkServer();
   }
 
-  printReport(config, results);
+  try {
+    final results = await measureSuites(config, suites);
+    if (results.isEmpty) {
+      throw ArgumentError(
+        'No benchmarks matched suite `${config.suite}`'
+        '${config.filter == null ? '' : ' and filter `${config.filter}`'}.',
+      );
+    }
+
+    printReport(config, results);
+  } finally {
+    if (needsServer) {
+      await closeOxyBenchmarks();
+      await http_suite.closeHttpBenchmarks();
+      await dio_suite.closeDioBenchmarks();
+      await closeBenchmarkServer();
+    }
+  }
 }
 
 List<BenchmarkSuite> _selectSuites(String value) {
@@ -55,6 +70,12 @@ List<BenchmarkSuite> _selectSuites(String value) {
   return selected.toSet().toList(growable: false);
 }
 
+bool _needsBenchmarkServer(BenchmarkSuite suite) {
+  return suite.name == oxySuite.name ||
+      suite.name == http_suite.httpSuite.name ||
+      suite.name == dio_suite.dioSuite.name;
+}
+
 void _printUsage() {
   print('Usage: dart bench/main.dart [--quick] [--json] [--suite=<name>] ');
   print('                           [--filter=<text>]');
@@ -64,5 +85,5 @@ void _printUsage() {
   print('Examples:');
   print('  dart bench/main.dart --quick');
   print('  dart bench/main.dart --suite=clients --json');
-  print('  dart bench/main.dart --suite=oxy --filter=body');
+  print('  dart bench/main.dart --suite=oxy --filter=network');
 }

--- a/bench/oxy.dart
+++ b/bench/oxy.dart
@@ -1,194 +1,70 @@
-import 'dart:async';
-
 import 'package:oxy/oxy.dart';
 
 import 'src/data.dart';
 import 'src/runner.dart';
+import 'src/server.dart';
 
 final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
-  SyncBenchmark(
-    group: 'request',
-    name: 'construct-get',
-    run: () {
-      consume(Request('/users/42', headers: headerPairs8));
-    },
-  ),
-  SyncBenchmark(
-    group: 'request',
-    name: 'copy-with-headers',
-    run: () {
-      consume(_request.copyWith(headers: headerPairs32));
-    },
-  ),
-  SyncBenchmark(
-    group: 'body',
-    name: 'construct-string',
-    run: () {
-      consume(Body(jsonText));
-    },
-  ),
-  SyncBenchmark(
-    group: 'body',
-    name: 'clone-bytes',
-    run: () {
-      consume(Body(largeBytes).clone());
+  AsyncBenchmark(
+    group: 'network',
+    name: 'get-empty',
+    run: () async {
+      final response = await _client.get('/empty');
+      consume(await response.bytes());
     },
   ),
   AsyncBenchmark(
-    group: 'body',
-    name: 'bytes-1k',
+    group: 'network',
+    name: 'get-json-decode',
     run: () async {
-      consume(await Body(smallBytes).bytes());
+      final response = await _client.get('/json');
+      consume(await response.json<Map<String, Object?>>());
     },
   ),
   AsyncBenchmark(
-    group: 'response',
-    name: 'bytes-1k',
+    group: 'network',
+    name: 'get-bytes-64k',
     run: () async {
-      consume(await Response.bytes(smallBytes).bytes());
+      final response = await _client.get('/bytes-64k');
+      consume(await response.bytes());
     },
   ),
   AsyncBenchmark(
-    group: 'response',
-    name: 'json-decode',
+    group: 'network',
+    name: 'post-json',
     run: () async {
-      consume(await Response.json(jsonPayload).json<Map<String, Object?>>());
+      final response = await _client.post('/json', json: jsonPayload);
+      consume(await response.json<Map<String, Object?>>());
     },
   ),
   AsyncBenchmark(
-    group: 'client',
-    name: 'send-no-middleware',
+    group: 'network',
+    name: 'post-bytes-64k',
     run: () async {
-      consume(await _plainClient.send(_request));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'request-json-body',
-    run: () async {
-      consume(await _plainClient.post('/users', json: jsonPayload));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'send-5-middleware',
-    run: () async {
-      consume(await _middlewareClient.send(_request));
-    },
-  ),
-  AsyncBenchmark(
-    group: 'client',
-    name: 'retry-replayable-body',
-    run: () async {
-      consume(await _retryClient.send(_putRequest));
+      final response = await _client.post(
+        '/bytes-64k',
+        headers: _octetHeaders,
+        body: largeBytes,
+      );
+      consume(await response.bytes());
     },
   ),
 ]);
 
-final _request = Request(
-  '/users/42',
-  headers: headerPairs8,
-  options: const RequestOptions(query: <String, Object?>{'include': 'profile'}),
-);
+const _octetHeaders = <String, String>{
+  'content-type': 'application/octet-stream',
+};
 
-final _putRequest = Request(
-  '/users/42',
-  method: 'PUT',
-  headers: const <String, String>{'content-type': 'application/octet-stream'},
-  body: Body(largeBytes),
-);
+Client? _clientInstance;
 
-final _plainClient = Client(
-  ClientOptions(
-    baseUrl: Uri.parse('https://example.test'),
-    transport: const _StaticTransport(),
-  ),
-);
-
-final _middlewareClient = Client(
-  ClientOptions(
-    baseUrl: Uri.parse('https://example.test'),
-    transport: const _StaticTransport(),
-    middleware: List<Middleware>.filled(5, const _NoopMiddleware()),
-  ),
-);
-
-final _retryClient = Client(
-  ClientOptions(
-    baseUrl: Uri.parse('https://example.test'),
-    transport: const _RetryTransport(),
-    retryPolicy: const RetryPolicy(
-      maxRetries: 2,
-      idempotentMethodsOnly: false,
-      baseDelay: Duration.zero,
-      maxDelay: Duration.zero,
-      jitterRatio: 0,
-    ),
-  ),
-);
-
-final class _StaticTransport implements Transport {
-  const _StaticTransport();
-
-  @override
-  PlatformCapability get capability => PlatformCapability.test;
-
-  @override
-  Future<void> close() => Future<void>.value();
-
-  @override
-  Future<Response> send(Request request, Context context) {
-    return Future<Response>.value(Response.bytes(const <int>[]));
-  }
+Client get _client {
+  return _clientInstance ??= Client(
+    ClientOptions(baseUrl: benchmarkServer.baseUri),
+  );
 }
 
-final class _RetryTransport implements Transport {
-  const _RetryTransport();
-
-  @override
-  PlatformCapability get capability => PlatformCapability.test;
-
-  @override
-  Future<void> close() => Future<void>.value();
-
-  @override
-  Future<Response> send(Request request, Context context) {
-    final status = context.attempt < 2 ? 503 : 200;
-    return Future<Response>.value(
-      Response.bytes(const <int>[], status: status),
-    );
-  }
-}
-
-final class _NoopMiddleware
-    implements
-        RequestTransformer,
-        AttemptTransformer,
-        AttemptResponseHandler,
-        FinalResponseHandler,
-        FinalFinallyHandler {
-  const _NoopMiddleware();
-
-  @override
-  Request onRequest(Request request, Context context) => request;
-
-  @override
-  Request onAttempt(Request request, Context context) => request;
-
-  @override
-  Response onAttemptResponse(
-    Request request,
-    Response response,
-    Context context,
-  ) {
-    return response;
-  }
-
-  @override
-  Response onResponse(Request request, Response response, Context context) {
-    return response;
-  }
-
-  @override
-  void onFinally(Request request, Context context) {}
+Future<void> closeOxyBenchmarks() async {
+  final client = _clientInstance;
+  _clientInstance = null;
+  await client?.close();
 }

--- a/bench/oxy.dart
+++ b/bench/oxy.dart
@@ -1,0 +1,451 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:ht/ht.dart' as ht;
+import 'package:oxy/oxy.dart';
+
+Object? benchmarkBlackHole;
+
+final _smallBytes = Uint8List.fromList(
+  List<int>.generate(1024, (index) => index & 0xff, growable: false),
+);
+final _largeBytes = Uint8List.fromList(
+  List<int>.generate(64 * 1024, (index) => index & 0xff, growable: false),
+);
+final _jsonPayload = <String, Object?>{
+  'id': 42,
+  'name': 'Oxy',
+  'tags': <String>['http', 'middleware', 'body'],
+  'active': true,
+};
+final _jsonText = jsonEncode(_jsonPayload);
+final _headerPairs8 = _headerPairs(8);
+final _headerPairs32 = _headerPairs(32);
+final _request = Request(
+  '/users/42',
+  headers: _headerPairs8,
+  options: const RequestOptions(query: <String, Object?>{'include': 'profile'}),
+);
+final _putRequest = Request(
+  '/users/42',
+  method: 'PUT',
+  headers: const <String, String>{'content-type': 'application/octet-stream'},
+  body: Body(_largeBytes),
+);
+
+void main(List<String> args) async {
+  final config = _RunConfig.fromArgs(args);
+  if (config.showHelp) {
+    _printUsage();
+    return;
+  }
+
+  final selected = _cases
+      .where((benchmark) => config.matches(benchmark))
+      .toList(growable: false);
+  if (selected.isEmpty) {
+    throw ArgumentError('No benchmarks matched filter: ${config.filter}');
+  }
+
+  final results = <_BenchmarkResult>[];
+  for (final benchmark in selected) {
+    results.add(await benchmark.measureCase(config));
+  }
+
+  if (config.json) {
+    print(jsonEncode(_jsonReport(config, results)));
+  } else {
+    _printReport(config, results);
+  }
+}
+
+final _cases = <_BenchmarkCase>[
+  _SyncBenchmark(
+    group: 'headers',
+    name: 'create-8',
+    run: () {
+      _consume(Headers(_headerPairs8));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'headers',
+    name: 'create-32',
+    run: () {
+      _consume(Headers(_headerPairs32));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'headers',
+    name: 'iterate-32',
+    run: () {
+      _consume(Headers(_headerPairs32).toList(growable: false));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'request',
+    name: 'construct-get',
+    run: () {
+      _consume(Request('/users/42', headers: _headerPairs8));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'request',
+    name: 'copy-with-headers',
+    run: () {
+      _consume(_request.copyWith(headers: _headerPairs32));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'body',
+    name: 'construct-string',
+    run: () {
+      _consume(Body(_jsonText));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'body',
+    name: 'construct-upstream-ht-body',
+    run: () {
+      _consume(Body(ht.Body(_largeBytes)));
+    },
+  ),
+  _SyncBenchmark(
+    group: 'body',
+    name: 'clone-bytes',
+    run: () {
+      _consume(Body(_largeBytes).clone());
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'body',
+    name: 'bytes-1k',
+    run: () async {
+      _consume(await Body(_smallBytes).bytes());
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'response',
+    name: 'bytes-1k',
+    run: () async {
+      _consume(await Response.bytes(_smallBytes).bytes());
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'response',
+    name: 'json-decode',
+    run: () async {
+      _consume(await Response.json(_jsonPayload).json<Map<String, Object?>>());
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'client',
+    name: 'send-no-middleware',
+    run: () async {
+      _consume(await _plainClient.send(_request));
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'client',
+    name: 'request-json-body',
+    run: () async {
+      _consume(await _plainClient.post('/users', json: _jsonPayload));
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'client',
+    name: 'send-5-middleware',
+    run: () async {
+      _consume(await _middlewareClient.send(_request));
+    },
+  ),
+  _AsyncBenchmark(
+    group: 'client',
+    name: 'retry-replayable-body',
+    run: () async {
+      _consume(await _retryClient.send(_putRequest));
+    },
+  ),
+];
+
+final _plainClient = Client(
+  ClientOptions(
+    baseUrl: Uri.parse('https://example.test'),
+    transport: const _StaticTransport(),
+  ),
+);
+final _middlewareClient = Client(
+  ClientOptions(
+    baseUrl: Uri.parse('https://example.test'),
+    transport: const _StaticTransport(),
+    middleware: List<Middleware>.filled(5, const _NoopMiddleware()),
+  ),
+);
+final _retryClient = Client(
+  ClientOptions(
+    baseUrl: Uri.parse('https://example.test'),
+    transport: const _RetryTransport(),
+    retryPolicy: const RetryPolicy(
+      maxRetries: 2,
+      idempotentMethodsOnly: false,
+      baseDelay: Duration.zero,
+      maxDelay: Duration.zero,
+      jitterRatio: 0,
+    ),
+  ),
+);
+
+List<MapEntry<String, String>> _headerPairs(int count) {
+  return List<MapEntry<String, String>>.generate(
+    count,
+    (index) => MapEntry('x-oxy-$index', 'value-$index'),
+    growable: false,
+  );
+}
+
+void _consume(Object? value) {
+  benchmarkBlackHole = value;
+}
+
+abstract interface class _BenchmarkCase {
+  String get group;
+  String get name;
+  Future<_BenchmarkResult> measureCase(_RunConfig config);
+}
+
+final class _SyncBenchmark extends BenchmarkBase implements _BenchmarkCase {
+  _SyncBenchmark({
+    required this.group,
+    required String name,
+    required void Function() run,
+  }) : _run = run,
+       super(name);
+
+  @override
+  final String group;
+  final void Function() _run;
+
+  @override
+  void run() => _run();
+
+  @override
+  void exercise() => run();
+
+  @override
+  Future<_BenchmarkResult> measureCase(_RunConfig config) async {
+    setup();
+    try {
+      BenchmarkBase.measureFor(warmup, config.warmupMillis);
+      final runtimeMicros = BenchmarkBase.measureFor(
+        exercise,
+        config.measureMillis,
+      );
+      return _BenchmarkResult(
+        group: group,
+        name: name,
+        runtimeMicros: runtimeMicros,
+      );
+    } finally {
+      teardown();
+    }
+  }
+}
+
+final class _AsyncBenchmark extends AsyncBenchmarkBase
+    implements _BenchmarkCase {
+  _AsyncBenchmark({
+    required this.group,
+    required String name,
+    required Future<void> Function() run,
+  }) : _run = run,
+       super(name);
+
+  @override
+  final String group;
+  final Future<void> Function() _run;
+
+  @override
+  Future<void> run() => _run();
+
+  @override
+  Future<_BenchmarkResult> measureCase(_RunConfig config) async {
+    await setup();
+    try {
+      await AsyncBenchmarkBase.measureFor(warmup, config.warmupMillis);
+      final runtimeMicros = await AsyncBenchmarkBase.measureFor(
+        exercise,
+        config.measureMillis,
+      );
+      return _BenchmarkResult(
+        group: group,
+        name: name,
+        runtimeMicros: runtimeMicros,
+      );
+    } finally {
+      await teardown();
+    }
+  }
+}
+
+final class _BenchmarkResult {
+  const _BenchmarkResult({
+    required this.group,
+    required this.name,
+    required this.runtimeMicros,
+  });
+
+  final String group;
+  final String name;
+  final double runtimeMicros;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'group': group,
+      'name': name,
+      'runtimeMicros': runtimeMicros,
+    };
+  }
+}
+
+final class _RunConfig {
+  const _RunConfig({
+    required this.json,
+    required this.quick,
+    required this.filter,
+    required this.showHelp,
+  });
+
+  factory _RunConfig.fromArgs(List<String> args) {
+    return _RunConfig(
+      json: args.contains('--json'),
+      quick: args.contains('--quick'),
+      filter: _optionValue(args, '--filter='),
+      showHelp: args.contains('--help') || args.contains('-h'),
+    );
+  }
+
+  final bool json;
+  final bool quick;
+  final String? filter;
+  final bool showHelp;
+
+  int get warmupMillis => quick ? 30 : 100;
+  int get measureMillis => quick ? 150 : 2000;
+
+  bool matches(_BenchmarkCase benchmark) {
+    final filter = this.filter;
+    if (filter == null || filter.isEmpty) {
+      return true;
+    }
+    return '${benchmark.group}.${benchmark.name}'.contains(filter);
+  }
+}
+
+String? _optionValue(List<String> args, String prefix) {
+  for (final arg in args) {
+    if (arg.startsWith(prefix)) {
+      return arg.substring(prefix.length);
+    }
+  }
+  return null;
+}
+
+Map<String, Object?> _jsonReport(
+  _RunConfig config,
+  List<_BenchmarkResult> results,
+) {
+  return <String, Object?>{
+    'runner': 'benchmark_harness',
+    'mode': config.quick ? 'quick' : 'full',
+    'unit': 'microseconds',
+    'warmupMillis': config.warmupMillis,
+    'measureMillis': config.measureMillis,
+    'filter': config.filter,
+    'benchmarks': results.map((result) => result.toJson()).toList(),
+  };
+}
+
+void _printReport(_RunConfig config, List<_BenchmarkResult> results) {
+  print('Oxy benchmarks (${config.quick ? 'quick' : 'full'})');
+  print('unit: microseconds per run');
+  print('');
+  for (final result in results) {
+    final label = '${result.group}.${result.name}'.padRight(34);
+    print('$label ${result.runtimeMicros.toStringAsFixed(3)}');
+  }
+}
+
+void _printUsage() {
+  print('Usage: dart bench/oxy.dart [--quick] [--json] [--filter=<text>]');
+  print('');
+  print('Examples:');
+  print('  dart bench/oxy.dart --quick');
+  print('  dart bench/oxy.dart --json --filter=body');
+}
+
+final class _StaticTransport implements Transport {
+  const _StaticTransport();
+
+  @override
+  PlatformCapability get capability => PlatformCapability.test;
+
+  @override
+  Future<void> close() => Future<void>.value();
+
+  @override
+  Future<Response> send(Request request, Context context) {
+    return Future<Response>.value(Response.bytes(const <int>[]));
+  }
+}
+
+final class _RetryTransport implements Transport {
+  const _RetryTransport();
+
+  @override
+  PlatformCapability get capability => PlatformCapability.test;
+
+  @override
+  Future<void> close() => Future<void>.value();
+
+  @override
+  Future<Response> send(Request request, Context context) {
+    final status = context.attempt < 2 ? 503 : 200;
+    return Future<Response>.value(
+      Response.bytes(const <int>[], status: status),
+    );
+  }
+}
+
+final class _NoopMiddleware
+    implements
+        RequestTransformer,
+        AttemptTransformer,
+        AttemptResponseHandler,
+        FinalResponseHandler,
+        FinalFinallyHandler {
+  const _NoopMiddleware();
+
+  @override
+  Request onRequest(Request request, Context context) => request;
+
+  @override
+  Request onAttempt(Request request, Context context) => request;
+
+  @override
+  Response onAttemptResponse(
+    Request request,
+    Response response,
+    Context context,
+  ) {
+    return response;
+  }
+
+  @override
+  Response onResponse(Request request, Response response, Context context) {
+    return response;
+  }
+
+  @override
+  void onFinally(Request request, Context context) {}
+}

--- a/bench/oxy.dart
+++ b/bench/oxy.dart
@@ -1,6 +1,7 @@
 import 'package:oxy/oxy.dart';
 
 import 'src/data.dart';
+import 'src/network.dart';
 import 'src/runner.dart';
 import 'src/server.dart';
 
@@ -9,7 +10,8 @@ final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
     group: 'network',
     name: 'get-empty',
     run: () async {
-      final response = await _client.get('/empty');
+      final response = await _client.get('/empty', headers: benchmarkHeaders);
+      checkBenchmarkStatus(response.status);
       consume(await response.bytes());
     },
   ),
@@ -17,7 +19,8 @@ final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
     group: 'network',
     name: 'get-json-decode',
     run: () async {
-      final response = await _client.get('/json');
+      final response = await _client.get('/json', headers: benchmarkHeaders);
+      checkBenchmarkStatus(response.status);
       consume(await response.json<Map<String, Object?>>());
     },
   ),
@@ -25,7 +28,11 @@ final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
     group: 'network',
     name: 'get-bytes-64k',
     run: () async {
-      final response = await _client.get('/bytes-64k');
+      final response = await _client.get(
+        '/bytes-64k',
+        headers: benchmarkHeaders,
+      );
+      checkBenchmarkStatus(response.status);
       consume(await response.bytes());
     },
   ),
@@ -34,6 +41,7 @@ final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
     name: 'post-json',
     run: () async {
       final response = await _client.post('/json', json: jsonPayload);
+      checkBenchmarkStatus(response.status);
       consume(await response.json<Map<String, Object?>>());
     },
   ),
@@ -43,17 +51,14 @@ final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
     run: () async {
       final response = await _client.post(
         '/bytes-64k',
-        headers: _octetHeaders,
+        headers: octetHeaders,
         body: largeBytes,
       );
+      checkBenchmarkStatus(response.status);
       consume(await response.bytes());
     },
   ),
 ]);
-
-const _octetHeaders = <String, String>{
-  'content-type': 'application/octet-stream',
-};
 
 Client? _clientInstance;
 

--- a/bench/oxy.dart
+++ b/bench/oxy.dart
@@ -1,173 +1,102 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:typed_data';
 
-import 'package:benchmark_harness/benchmark_harness.dart';
-import 'package:ht/ht.dart' as ht;
 import 'package:oxy/oxy.dart';
 
-Object? benchmarkBlackHole;
+import 'src/data.dart';
+import 'src/runner.dart';
 
-final _smallBytes = Uint8List.fromList(
-  List<int>.generate(1024, (index) => index & 0xff, growable: false),
-);
-final _largeBytes = Uint8List.fromList(
-  List<int>.generate(64 * 1024, (index) => index & 0xff, growable: false),
-);
-final _jsonPayload = <String, Object?>{
-  'id': 42,
-  'name': 'Oxy',
-  'tags': <String>['http', 'middleware', 'body'],
-  'active': true,
-};
-final _jsonText = jsonEncode(_jsonPayload);
-final _headerPairs8 = _headerPairs(8);
-final _headerPairs32 = _headerPairs(32);
+final oxySuite = BenchmarkSuite('oxy', <BenchmarkCase>[
+  SyncBenchmark(
+    group: 'request',
+    name: 'construct-get',
+    run: () {
+      consume(Request('/users/42', headers: headerPairs8));
+    },
+  ),
+  SyncBenchmark(
+    group: 'request',
+    name: 'copy-with-headers',
+    run: () {
+      consume(_request.copyWith(headers: headerPairs32));
+    },
+  ),
+  SyncBenchmark(
+    group: 'body',
+    name: 'construct-string',
+    run: () {
+      consume(Body(jsonText));
+    },
+  ),
+  SyncBenchmark(
+    group: 'body',
+    name: 'clone-bytes',
+    run: () {
+      consume(Body(largeBytes).clone());
+    },
+  ),
+  AsyncBenchmark(
+    group: 'body',
+    name: 'bytes-1k',
+    run: () async {
+      consume(await Body(smallBytes).bytes());
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'bytes-1k',
+    run: () async {
+      consume(await Response.bytes(smallBytes).bytes());
+    },
+  ),
+  AsyncBenchmark(
+    group: 'response',
+    name: 'json-decode',
+    run: () async {
+      consume(await Response.json(jsonPayload).json<Map<String, Object?>>());
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'send-no-middleware',
+    run: () async {
+      consume(await _plainClient.send(_request));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'request-json-body',
+    run: () async {
+      consume(await _plainClient.post('/users', json: jsonPayload));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'send-5-middleware',
+    run: () async {
+      consume(await _middlewareClient.send(_request));
+    },
+  ),
+  AsyncBenchmark(
+    group: 'client',
+    name: 'retry-replayable-body',
+    run: () async {
+      consume(await _retryClient.send(_putRequest));
+    },
+  ),
+]);
+
 final _request = Request(
   '/users/42',
-  headers: _headerPairs8,
+  headers: headerPairs8,
   options: const RequestOptions(query: <String, Object?>{'include': 'profile'}),
 );
+
 final _putRequest = Request(
   '/users/42',
   method: 'PUT',
   headers: const <String, String>{'content-type': 'application/octet-stream'},
-  body: Body(_largeBytes),
+  body: Body(largeBytes),
 );
-
-void main(List<String> args) async {
-  final config = _RunConfig.fromArgs(args);
-  if (config.showHelp) {
-    _printUsage();
-    return;
-  }
-
-  final selected = _cases
-      .where((benchmark) => config.matches(benchmark))
-      .toList(growable: false);
-  if (selected.isEmpty) {
-    throw ArgumentError('No benchmarks matched filter: ${config.filter}');
-  }
-
-  final results = <_BenchmarkResult>[];
-  for (final benchmark in selected) {
-    results.add(await benchmark.measureCase(config));
-  }
-
-  if (config.json) {
-    print(jsonEncode(_jsonReport(config, results)));
-  } else {
-    _printReport(config, results);
-  }
-}
-
-final _cases = <_BenchmarkCase>[
-  _SyncBenchmark(
-    group: 'headers',
-    name: 'create-8',
-    run: () {
-      _consume(Headers(_headerPairs8));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'headers',
-    name: 'create-32',
-    run: () {
-      _consume(Headers(_headerPairs32));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'headers',
-    name: 'iterate-32',
-    run: () {
-      _consume(Headers(_headerPairs32).toList(growable: false));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'request',
-    name: 'construct-get',
-    run: () {
-      _consume(Request('/users/42', headers: _headerPairs8));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'request',
-    name: 'copy-with-headers',
-    run: () {
-      _consume(_request.copyWith(headers: _headerPairs32));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'body',
-    name: 'construct-string',
-    run: () {
-      _consume(Body(_jsonText));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'body',
-    name: 'construct-upstream-ht-body',
-    run: () {
-      _consume(Body(ht.Body(_largeBytes)));
-    },
-  ),
-  _SyncBenchmark(
-    group: 'body',
-    name: 'clone-bytes',
-    run: () {
-      _consume(Body(_largeBytes).clone());
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'body',
-    name: 'bytes-1k',
-    run: () async {
-      _consume(await Body(_smallBytes).bytes());
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'response',
-    name: 'bytes-1k',
-    run: () async {
-      _consume(await Response.bytes(_smallBytes).bytes());
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'response',
-    name: 'json-decode',
-    run: () async {
-      _consume(await Response.json(_jsonPayload).json<Map<String, Object?>>());
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'client',
-    name: 'send-no-middleware',
-    run: () async {
-      _consume(await _plainClient.send(_request));
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'client',
-    name: 'request-json-body',
-    run: () async {
-      _consume(await _plainClient.post('/users', json: _jsonPayload));
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'client',
-    name: 'send-5-middleware',
-    run: () async {
-      _consume(await _middlewareClient.send(_request));
-    },
-  ),
-  _AsyncBenchmark(
-    group: 'client',
-    name: 'retry-replayable-body',
-    run: () async {
-      _consume(await _retryClient.send(_putRequest));
-    },
-  ),
-];
 
 final _plainClient = Client(
   ClientOptions(
@@ -175,6 +104,7 @@ final _plainClient = Client(
     transport: const _StaticTransport(),
   ),
 );
+
 final _middlewareClient = Client(
   ClientOptions(
     baseUrl: Uri.parse('https://example.test'),
@@ -182,6 +112,7 @@ final _middlewareClient = Client(
     middleware: List<Middleware>.filled(5, const _NoopMiddleware()),
   ),
 );
+
 final _retryClient = Client(
   ClientOptions(
     baseUrl: Uri.parse('https://example.test'),
@@ -195,194 +126,6 @@ final _retryClient = Client(
     ),
   ),
 );
-
-List<MapEntry<String, String>> _headerPairs(int count) {
-  return List<MapEntry<String, String>>.generate(
-    count,
-    (index) => MapEntry('x-oxy-$index', 'value-$index'),
-    growable: false,
-  );
-}
-
-void _consume(Object? value) {
-  benchmarkBlackHole = value;
-}
-
-abstract interface class _BenchmarkCase {
-  String get group;
-  String get name;
-  Future<_BenchmarkResult> measureCase(_RunConfig config);
-}
-
-final class _SyncBenchmark extends BenchmarkBase implements _BenchmarkCase {
-  _SyncBenchmark({
-    required this.group,
-    required String name,
-    required void Function() run,
-  }) : _run = run,
-       super(name);
-
-  @override
-  final String group;
-  final void Function() _run;
-
-  @override
-  void run() => _run();
-
-  @override
-  void exercise() => run();
-
-  @override
-  Future<_BenchmarkResult> measureCase(_RunConfig config) async {
-    setup();
-    try {
-      BenchmarkBase.measureFor(warmup, config.warmupMillis);
-      final runtimeMicros = BenchmarkBase.measureFor(
-        exercise,
-        config.measureMillis,
-      );
-      return _BenchmarkResult(
-        group: group,
-        name: name,
-        runtimeMicros: runtimeMicros,
-      );
-    } finally {
-      teardown();
-    }
-  }
-}
-
-final class _AsyncBenchmark extends AsyncBenchmarkBase
-    implements _BenchmarkCase {
-  _AsyncBenchmark({
-    required this.group,
-    required String name,
-    required Future<void> Function() run,
-  }) : _run = run,
-       super(name);
-
-  @override
-  final String group;
-  final Future<void> Function() _run;
-
-  @override
-  Future<void> run() => _run();
-
-  @override
-  Future<_BenchmarkResult> measureCase(_RunConfig config) async {
-    await setup();
-    try {
-      await AsyncBenchmarkBase.measureFor(warmup, config.warmupMillis);
-      final runtimeMicros = await AsyncBenchmarkBase.measureFor(
-        exercise,
-        config.measureMillis,
-      );
-      return _BenchmarkResult(
-        group: group,
-        name: name,
-        runtimeMicros: runtimeMicros,
-      );
-    } finally {
-      await teardown();
-    }
-  }
-}
-
-final class _BenchmarkResult {
-  const _BenchmarkResult({
-    required this.group,
-    required this.name,
-    required this.runtimeMicros,
-  });
-
-  final String group;
-  final String name;
-  final double runtimeMicros;
-
-  Map<String, Object?> toJson() {
-    return <String, Object?>{
-      'group': group,
-      'name': name,
-      'runtimeMicros': runtimeMicros,
-    };
-  }
-}
-
-final class _RunConfig {
-  const _RunConfig({
-    required this.json,
-    required this.quick,
-    required this.filter,
-    required this.showHelp,
-  });
-
-  factory _RunConfig.fromArgs(List<String> args) {
-    return _RunConfig(
-      json: args.contains('--json'),
-      quick: args.contains('--quick'),
-      filter: _optionValue(args, '--filter='),
-      showHelp: args.contains('--help') || args.contains('-h'),
-    );
-  }
-
-  final bool json;
-  final bool quick;
-  final String? filter;
-  final bool showHelp;
-
-  int get warmupMillis => quick ? 30 : 100;
-  int get measureMillis => quick ? 150 : 2000;
-
-  bool matches(_BenchmarkCase benchmark) {
-    final filter = this.filter;
-    if (filter == null || filter.isEmpty) {
-      return true;
-    }
-    return '${benchmark.group}.${benchmark.name}'.contains(filter);
-  }
-}
-
-String? _optionValue(List<String> args, String prefix) {
-  for (final arg in args) {
-    if (arg.startsWith(prefix)) {
-      return arg.substring(prefix.length);
-    }
-  }
-  return null;
-}
-
-Map<String, Object?> _jsonReport(
-  _RunConfig config,
-  List<_BenchmarkResult> results,
-) {
-  return <String, Object?>{
-    'runner': 'benchmark_harness',
-    'mode': config.quick ? 'quick' : 'full',
-    'unit': 'microseconds',
-    'warmupMillis': config.warmupMillis,
-    'measureMillis': config.measureMillis,
-    'filter': config.filter,
-    'benchmarks': results.map((result) => result.toJson()).toList(),
-  };
-}
-
-void _printReport(_RunConfig config, List<_BenchmarkResult> results) {
-  print('Oxy benchmarks (${config.quick ? 'quick' : 'full'})');
-  print('unit: microseconds per run');
-  print('');
-  for (final result in results) {
-    final label = '${result.group}.${result.name}'.padRight(34);
-    print('$label ${result.runtimeMicros.toStringAsFixed(3)}');
-  }
-}
-
-void _printUsage() {
-  print('Usage: dart bench/oxy.dart [--quick] [--json] [--filter=<text>]');
-  print('');
-  print('Examples:');
-  print('  dart bench/oxy.dart --quick');
-  print('  dart bench/oxy.dart --json --filter=body');
-}
 
 final class _StaticTransport implements Transport {
   const _StaticTransport();

--- a/bench/src/data.dart
+++ b/bench/src/data.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+final smallBytes = Uint8List.fromList(
+  List<int>.generate(1024, (index) => index & 0xff, growable: false),
+);
+
+final largeBytes = Uint8List.fromList(
+  List<int>.generate(64 * 1024, (index) => index & 0xff, growable: false),
+);
+
+final jsonPayload = <String, Object?>{
+  'id': 42,
+  'name': 'Oxy',
+  'tags': <String>['http', 'middleware', 'body'],
+  'active': true,
+};
+
+final jsonText = jsonEncode(jsonPayload);
+
+final headerPairs8 = headerPairs(8);
+final headerPairs32 = headerPairs(32);
+
+List<MapEntry<String, String>> headerPairs(int count) {
+  return List<MapEntry<String, String>>.generate(
+    count,
+    (index) => MapEntry('x-oxy-$index', 'value-$index'),
+    growable: false,
+  );
+}

--- a/bench/src/network.dart
+++ b/bench/src/network.dart
@@ -1,0 +1,17 @@
+import 'data.dart';
+
+final benchmarkHeaders = Map<String, String>.fromEntries(headerPairs8);
+
+const jsonHeaders = <String, String>{
+  'content-type': 'application/json; charset=utf-8',
+};
+
+const octetHeaders = <String, String>{
+  'content-type': 'application/octet-stream',
+};
+
+void checkBenchmarkStatus(int? status) {
+  if (status == null || status < 200 || status >= 300) {
+    throw StateError('Benchmark server rejected request with HTTP $status.');
+  }
+}

--- a/bench/src/runner.dart
+++ b/bench/src/runner.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+Object? benchmarkBlackHole;
+
+void consume(Object? value) {
+  benchmarkBlackHole = value;
+}
+
+final class BenchmarkSuite {
+  const BenchmarkSuite(this.name, this.cases);
+
+  final String name;
+  final List<BenchmarkCase> cases;
+}
+
+abstract interface class BenchmarkCase {
+  String get group;
+  String get name;
+  Future<BenchmarkResult> measureCase(RunConfig config);
+}
+
+final class SyncBenchmark extends BenchmarkBase implements BenchmarkCase {
+  SyncBenchmark({
+    required this.group,
+    required String name,
+    required void Function() run,
+  }) : _run = run,
+       super(name);
+
+  @override
+  final String group;
+  final void Function() _run;
+
+  @override
+  void run() => _run();
+
+  @override
+  void exercise() => run();
+
+  @override
+  Future<BenchmarkResult> measureCase(RunConfig config) async {
+    setup();
+    try {
+      BenchmarkBase.measureFor(warmup, config.warmupMillis);
+      final runtimeMicros = BenchmarkBase.measureFor(
+        exercise,
+        config.measureMillis,
+      );
+      return BenchmarkResult(
+        group: group,
+        name: name,
+        runtimeMicros: runtimeMicros,
+      );
+    } finally {
+      teardown();
+    }
+  }
+}
+
+final class AsyncBenchmark extends AsyncBenchmarkBase implements BenchmarkCase {
+  AsyncBenchmark({
+    required this.group,
+    required String name,
+    required Future<void> Function() run,
+  }) : _run = run,
+       super(name);
+
+  @override
+  final String group;
+  final Future<void> Function() _run;
+
+  @override
+  Future<void> run() => _run();
+
+  @override
+  Future<BenchmarkResult> measureCase(RunConfig config) async {
+    await setup();
+    try {
+      await AsyncBenchmarkBase.measureFor(warmup, config.warmupMillis);
+      final runtimeMicros = await AsyncBenchmarkBase.measureFor(
+        exercise,
+        config.measureMillis,
+      );
+      return BenchmarkResult(
+        group: group,
+        name: name,
+        runtimeMicros: runtimeMicros,
+      );
+    } finally {
+      await teardown();
+    }
+  }
+}
+
+final class BenchmarkResult {
+  const BenchmarkResult({
+    this.suite = '',
+    required this.group,
+    required this.name,
+    required this.runtimeMicros,
+  });
+
+  final String suite;
+  final String group;
+  final String name;
+  final double runtimeMicros;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'suite': suite,
+      'group': group,
+      'name': name,
+      'runtimeMicros': runtimeMicros,
+    };
+  }
+}
+
+final class RunConfig {
+  const RunConfig({
+    required this.json,
+    required this.quick,
+    required this.suite,
+    required this.filter,
+    required this.showHelp,
+  });
+
+  factory RunConfig.fromArgs(List<String> args) {
+    return RunConfig(
+      json: args.contains('--json'),
+      quick: args.contains('--quick'),
+      suite: _optionValue(args, '--suite=') ?? 'baseline,oxy',
+      filter: _optionValue(args, '--filter='),
+      showHelp: args.contains('--help') || args.contains('-h'),
+    );
+  }
+
+  final bool json;
+  final bool quick;
+  final String suite;
+  final String? filter;
+  final bool showHelp;
+
+  int get warmupMillis => quick ? 30 : 100;
+  int get measureMillis => quick ? 150 : 2000;
+
+  bool matches(BenchmarkSuite suite, BenchmarkCase benchmark) {
+    final filter = this.filter;
+    if (filter == null || filter.isEmpty) {
+      return true;
+    }
+    return '${suite.name}.${benchmark.group}.${benchmark.name}'.contains(
+      filter,
+    );
+  }
+}
+
+Future<List<BenchmarkResult>> measureSuites(
+  RunConfig config,
+  Iterable<BenchmarkSuite> suites,
+) async {
+  final results = <BenchmarkResult>[];
+  for (final suite in suites) {
+    final selected = suite.cases.where((benchmark) {
+      return config.matches(suite, benchmark);
+    });
+    for (final benchmark in selected) {
+      final result = await benchmark.measureCase(config);
+      results.add(
+        BenchmarkResult(
+          suite: suite.name,
+          group: result.group,
+          name: result.name,
+          runtimeMicros: result.runtimeMicros,
+        ),
+      );
+    }
+  }
+  return results;
+}
+
+void printReport(RunConfig config, List<BenchmarkResult> results) {
+  if (config.json) {
+    print(jsonEncode(jsonReport(config, results)));
+    return;
+  }
+
+  print('Oxy benchmarks (${config.quick ? 'quick' : 'full'})');
+  print('unit: microseconds per run');
+  print('');
+  for (final result in results) {
+    final label = '${result.suite}.${result.group}.${result.name}'.padRight(42);
+    print('$label ${result.runtimeMicros.toStringAsFixed(3)}');
+  }
+}
+
+Map<String, Object?> jsonReport(
+  RunConfig config,
+  List<BenchmarkResult> results,
+) {
+  return <String, Object?>{
+    'runner': 'benchmark_harness',
+    'mode': config.quick ? 'quick' : 'full',
+    'unit': 'microseconds',
+    'suite': config.suite,
+    'filter': config.filter,
+    'warmupMillis': config.warmupMillis,
+    'measureMillis': config.measureMillis,
+    'benchmarks': results.map((result) => result.toJson()).toList(),
+  };
+}
+
+String? _optionValue(List<String> args, String prefix) {
+  for (final arg in args) {
+    if (arg.startsWith(prefix)) {
+      return arg.substring(prefix.length);
+    }
+  }
+  return null;
+}

--- a/bench/src/server.dart
+++ b/bench/src/server.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'data.dart';
+
+BenchmarkServer? _activeServer;
+final _jsonContentLength = utf8.encode(jsonText).length;
+
+BenchmarkServer get benchmarkServer {
+  final server = _activeServer;
+  if (server == null) {
+    throw StateError('Benchmark server has not been started.');
+  }
+  return server;
+}
+
+Future<BenchmarkServer> startBenchmarkServer() async {
+  final active = _activeServer;
+  if (active != null) {
+    return active;
+  }
+
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final benchmarkServer = BenchmarkServer._(server);
+  _activeServer = benchmarkServer;
+  unawaited(server.forEach(benchmarkServer._handleRequest));
+  return benchmarkServer;
+}
+
+Future<void> closeBenchmarkServer() async {
+  final server = _activeServer;
+  _activeServer = null;
+  await server?._server.close(force: true);
+}
+
+final class BenchmarkServer {
+  BenchmarkServer._(this._server)
+    : baseUri = Uri.parse('http://${_server.address.host}:${_server.port}');
+
+  final HttpServer _server;
+  final Uri baseUri;
+
+  Uri uri(String path) => baseUri.replace(path: path);
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    try {
+      switch ((request.method, request.uri.path)) {
+        case ('GET', '/empty'):
+          request.response.contentLength = 0;
+        case ('GET', '/json'):
+          _writeJson(request.response);
+        case ('GET', '/bytes-64k'):
+          _writeBytes(request.response);
+        case ('POST', '/json'):
+          final bytes = await _drainRequest(request);
+          if (bytes == _jsonContentLength) {
+            request.response.headers.set('x-request-bytes', bytes.toString());
+            _writeJson(request.response);
+          } else {
+            _writeBadRequest(request.response);
+          }
+        case ('POST', '/bytes-64k'):
+          final bytes = await _drainRequest(request);
+          if (bytes == largeBytes.length) {
+            request.response.headers.set('x-request-bytes', bytes.toString());
+            request.response.contentLength = 0;
+          } else {
+            _writeBadRequest(request.response);
+          }
+        default:
+          await _drainRequest(request);
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..write('missing');
+      }
+    } finally {
+      await request.response.close();
+    }
+  }
+
+  void _writeJson(HttpResponse response) {
+    response.headers.contentType = ContentType.json;
+    response.contentLength = _jsonContentLength;
+    response.write(jsonText);
+  }
+
+  void _writeBytes(HttpResponse response) {
+    response.headers.contentType = ContentType.binary;
+    response.contentLength = largeBytes.length;
+    response.add(largeBytes);
+  }
+
+  void _writeBadRequest(HttpResponse response) {
+    response
+      ..statusCode = HttpStatus.badRequest
+      ..write('unexpected request body');
+  }
+
+  Future<int> _drainRequest(HttpRequest request) async {
+    var bytes = 0;
+    await for (final chunk in request) {
+      bytes += chunk.length;
+    }
+    return bytes;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   patchwork: ^0.5.0
 
 dev_dependencies:
+  benchmark_harness: ^2.4.0
   lints: ^6.0.0
   stream_channel: ^2.1.2
   test: ^1.26.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
 
 dev_dependencies:
   benchmark_harness: ^2.4.0
+  dio: ^5.9.2
+  http: ^1.6.0
   lints: ^6.0.0
   stream_channel: ^2.1.2
   test: ^1.26.2


### PR DESCRIPTION
## Summary

Add a local benchmark harness for Oxy and comparable Dart HTTP clients:

- `bench/main.dart` is the single runner entrypoint with quick/full modes, suite selection, filtering, and JSON output.
- `bench/baseline.dart` measures lower-level JSON, bytes, `ht.Headers`, and `ht.Body` costs.
- `bench/oxy.dart`, `bench/http.dart`, and `bench/dio.dart` compare real client requests against the same loopback `HttpServer`.
- `bench/src/server.dart` serves fixed GET/POST scenarios and drains plus validates POST request bodies, so upload paths are included in the comparison.
- README positioning no longer promotes alternative HTTP libraries from Oxy's own feature list.

Client suites now use the same real network scenarios: `GET /empty`, `GET /json`, `GET /bytes-64k`, `POST /json`, and `POST /bytes-64k`. This keeps the comparison simple: same local server, same payloads, no mock transports, no custom Dio adapter, and no middleware/interceptor tuning.

This remains a local/manual benchmark tool rather than a CI performance gate.

No linked issue; this is a standalone performance benchmark PR.

## Validation

- `dart format --output=none --set-exit-if-changed bench/main.dart bench/oxy.dart bench/http.dart bench/dio.dart bench/src/server.dart`
- `dart analyze`
- `dart bench/main.dart --quick --json`
- `dart bench/main.dart --quick --suite=clients --json`
- `dart bench/main.dart --suite=clients --json`
- `dart test -p vm`
- `dart pub publish --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive HTTP benchmarking suite supporting multiple HTTP clients with test cases for GET/POST requests, JSON payload handling, and binary data transfers
  * Includes configurable benchmark runner with command-line options and reporting formats

* **Documentation**
  * Minor README clarifications

* **Chores**
  * Added benchmark-related development dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->